### PR TITLE
Fix broken editUrl in docs caused by master -> main base branch change

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -89,13 +89,13 @@ module.exports = {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
           editUrl:
-            "https://github.com/JonnyBurger/remotion/edit/master/packages/docs/",
+            "https://github.com/JonnyBurger/remotion/edit/main/packages/docs/",
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
           editUrl:
-            "https://github.com/Jonnyburger/remotion/edit/master/packages/docs/blog/",
+            "https://github.com/Jonnyburger/remotion/edit/main/packages/docs/blog/",
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),


### PR DESCRIPTION
When viewing [the docs](https://www.remotion.dev/docs/), I noticed that the 'Edit this page' link uses the master branch, but the base branch for the repo is `main`, so the link 404's. This should fix that issue.