### PR TITLE
fix for windows cp -> copy

### DIFF
--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -29,6 +29,6 @@ export const bundle = async (entryPoint: string): Promise<string> => {
 	if (errors.length > 0) {
 		throw new Error(errors[0].message + '\n' + errors[0].details);
 	}
-	await execa('cp', [path.join(__dirname, '..', 'web', 'index.html'), tmpDir]);
+	await execa('copy', [path.join(__dirname, '..', 'web', 'index.html'), tmpDir]);
 	return tmpDir;
 };

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -29,6 +29,6 @@ export const bundle = async (entryPoint: string): Promise<string> => {
 	if (errors.length > 0) {
 		throw new Error(errors[0].message + '\n' + errors[0].details);
 	}
-	await execa('copy', [path.join(__dirname, '..', 'web', 'index.html'), tmpDir]);
+	await execa(process.platform === 'win32' ? 'copy' : 'cp', [path.join(__dirname, '..', 'web', 'index.html'), tmpDir]);
 	return tmpDir;
 };


### PR DESCRIPTION
When using NPM on Windows I'm getting the a `spawn cp ENOENT`-Error.
```
Error: Command failed with ENOENT: cp {path}\node_modules\@remotion\bundler\web\index.html
{tempPath}\Temp\react-motion-graphicsXYlAK9
```
Therefore I changed `cp` to `copy` and now it works. Do you think this will have negative impact on Apple or Linux users?