### PR TITLE
Use `npm init video` instead of `npx create-video`

### DIFF
--- a/packages/docs/docs/getting-started.md
+++ b/packages/docs/docs/getting-started.md
@@ -25,7 +25,7 @@ yarn create video
 or
 
 ```bash
-npx create-video
+npm init video
 ```
 
 That's it! Wait for the installation to be finished and follow the instructions in the terminal.


### PR DESCRIPTION
This PR updates the docs to use `npm init`, the `npm` counterpart of `yarn create`.