### PR TITLE
Remove term "open source"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ For bigger projects, please coordinate with [Jonny Burger](https://jonny.io) to 
 
 Please note that since I charge for Remotion when companies are using it, this is a **commercial project** by me (Jonny Burger). By sending pull requests, you agree that I can use your code changes in a commercial context.
 
-Furthermore, also notice that unlike most open source project, you **cannot redistribute** this project. Please see [LICENSE.md](LICENSE.md) for what's allowed and what's not.
+Furthermore, also note that you **cannot redistribute** this project. Please see [LICENSE.md](LICENSE.md) for what's allowed and what's not.
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE-OF-CONDUCT.md). By participating in this project you agree to abide by its terms.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # Remotion License
 
-Depending on the type of your legal entity, you are granted permission to use Remotion for your project. Individuals and small companies are allowed to use Remotion create videos for free (even commercial), while a company license is required for for-profit organisations of a certain size. This two-tier system was designed to ensure funding for this project while still allowing it to be open source. Read below for the exact terms of use.
+Depending on the type of your legal entity, you are granted permission to use Remotion for your project. Individuals and small companies are allowed to use Remotion create videos for free (even commercial), while a company license is required for for-profit organisations of a certain size. This two-tier system was designed to ensure funding for this project while still allowing the source code to be available and the program to be free for most. Read below for the exact terms of use.
 
 - [Free license](#free-license)
 - [Company license](#company-license)

--- a/packages/docs/docs/license.md
+++ b/packages/docs/docs/license.md
@@ -4,6 +4,6 @@ title: License & Pricing
 ---
 
 Remotion ships with a separate license for individuals and companies.
-While Remotion is free to use for the former, for some teams a company license is required. Unlike many open source projects, it is not allowed to clone or fork Remotions code for the purpose of creating a competitor.
+While Remotion is free to use for the former, for some teams a company license is required. Unlike many projects on Github, it is not allowed to clone or fork Remotions code for the purpose of creating a competitor.
 
 Please read the [LICENSE file](https://github.com/JonnyBurger/remotion/blob/main/LICENSE.md) before using Remotion and [contact the author](mailto:hi@jonny.io) for pricing of the company license.


### PR DESCRIPTION
Although I thought of Remotion as an open source project, technically it is not open source because the license tells you cannot redistribute Remotion on your own.

Now this doesn't mean that Remotion is closed source or anything, in many ways it works just like all OSS projects, except that there is a clause that big companies cannot use it for free, and therefore, I also have to close the loophole of being able to fork and redistribute.

Nonetheless I don't wanna throw around the word 'open source' when it technically doesn't meet the definition.

I took the feedback from #47 and changed the wording. I didn't wanna say "unlike open source projects", because it sounds like Remotion is closed source. Therefore I said "unlike most projects on Github".

Fixes #47 