### PR TITLE
feat(renderer): improve render algorithm

### DIFF
--- a/packages/core/src/RemotionRoot.tsx
+++ b/packages/core/src/RemotionRoot.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {useCallback, useLayoutEffect, useMemo, useState} from 'react';
 import {
 	CompositionManager,
 	CompositionManagerContext,
@@ -11,6 +11,7 @@ import {
 	TimelineContext,
 	TimelineContextValue,
 } from './timeline-position-state';
+import { delayRender, continueRender } from './ready-manager';
 
 export const RemotionRoot: React.FC = ({children}) => {
 	// Wontfix, expected to have
@@ -22,6 +23,16 @@ export const RemotionRoot: React.FC = ({children}) => {
 	const [sequences, setSequences] = useState<TSequence[]>([]);
 	const [frame, setFrame] = useState<number>(0);
 	const [playing, setPlaying] = useState<boolean>(false);
+
+	useLayoutEffect(() => {
+		if (typeof window !== 'undefined') {
+			window.remotion_setFrame = (f: number) => {
+				const id = delayRender()
+				setFrame(f)
+				requestAnimationFrame(() => continueRender(id))
+			}
+		}
+	}, [])
 
 	const registerComposition = useCallback(<T,>(comp: TComposition<T>) => {
 		setCompositions((comps) => {

--- a/packages/core/src/ready-manager.ts
+++ b/packages/core/src/ready-manager.ts
@@ -31,5 +31,6 @@ declare global {
 	interface Window {
 		ready: boolean;
 		getStaticCompositions: () => TCompMetadata[];
+		remotion_setFrame: (frame: number) => void
 	}
 }

--- a/packages/core/src/use-frame.ts
+++ b/packages/core/src/use-frame.ts
@@ -5,10 +5,6 @@ import {useTimelinePosition} from './timeline-position-state';
 export const useAbsoluteCurrentFrame = (): number => {
 	const timelinePosition = useTimelinePosition();
 
-	const param = new URLSearchParams(window.location.search).get('frame');
-	if (param !== null) {
-		return Number(param);
-	}
 	return timelinePosition;
 };
 

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -67,21 +67,13 @@ export const provideScreenshot = async ({
 	imageFormat: ImageFormat;
 	quality: number | undefined;
 	options: {
-		site: string;
+		frame: number
 		output: string;
-		width: number;
-		height: number;
-	};
+	}
 }): Promise<void> => {
-	page.setViewport({
-		width: options.width,
-		height: options.height,
-		deviceScaleFactor: 1,
-	});
-	page.on('error', console.error);
-	page.on('pageerror', console.error);
-
-	await page.goto(options.site);
+	await page.evaluate((frame) => {
+		window.remotion_setFrame(frame)
+	}, options.frame);
 	await page.waitForFunction('window.ready === true');
 
 	await screenshotDOMElement({

--- a/packages/renderer/src/render.ts
+++ b/packages/renderer/src/render.ts
@@ -2,8 +2,8 @@ import path from 'path';
 import {VideoConfig} from 'remotion';
 import {openBrowser, provideScreenshot} from '.';
 import {getActualConcurrency} from './get-concurrency';
-import {Pool} from './pool'
 import {DEFAULT_IMAGE_FORMAT, ImageFormat} from './image-format';
+import {Pool} from './pool';
 
 export const renderFrames = async ({
 	config,
@@ -36,10 +36,25 @@ export const renderFrames = async ({
 	const actualParallelism = getActualConcurrency(parallelism ?? null);
 
 	const browser = await openBrowser();
-	const pool = new Pool(await Promise.all(
-		new Array(actualParallelism).fill(true).map(() => browser.newPage())
-	));
-	
+	const pages = new Array(actualParallelism).fill(true).map(async () => {
+		const page = await browser.newPage();
+		page.setViewport({
+			width: config.width,
+			height: config.height,
+			deviceScaleFactor: 1,
+		});
+		page.on('error', console.error);
+		page.on('pageerror', console.error);
+
+		const site = `file://${webpackBundle}/index.html?composition=${compositionId}&props=${encodeURIComponent(
+			JSON.stringify(userProps)
+		)}`;
+		await page.goto(site);
+		return page;
+	});
+
+	const pool = new Pool(await Promise.all(pages));
+
 	const {durationInFrames: frames} = config;
 	let framesRendered = 0;
 	onStart();
@@ -50,19 +65,14 @@ export const renderFrames = async ({
 			.map(async (f) => {
 				const freePage = await pool.acquire();
 				try {
-					const site = `file://${webpackBundle}/index.html?composition=${compositionId}&frame=${f}&props=${encodeURIComponent(
-						JSON.stringify(userProps)
-					)}`;
 					await provideScreenshot({
 						page: freePage,
-						options: {
-							output: path.join(outputDir, `element-${f}.${imageFormat}`),
-							site,
-							height: config.height,
-							width: config.width,
-						},
 						imageFormat,
 						quality,
+						options: {
+							frame: f,
+							output: path.join(outputDir, `element-${f}.${imageFormat}`),
+						},
 					});
 				} catch (err) {
 					console.log('Error taking screenshot', err);


### PR DESCRIPTION
Hi, this is third pr 🙌🏻 

I improve render algorithm

In main branch video renders in next steps:

```
for all frames
- open page
- load  page
- select frame
- load resources
- take screenshot
```

In my pr: 

```
- open page
- load  page

for all frames
- select frame
- load resources
- take screenshot
```

So all resources and pages will load only ones and this is much faster! I get like 10-15% faster results for short videos and this numbers will bigger for longer videos.
