### PR TITLE
only lint typescript-eslint on typescript files

### DIFF
--- a/packages/create-video/_template/package.json
+++ b/packages/create-video/_template/package.json
@@ -7,7 +7,7 @@
 		"build": "remotion render src/index.tsx HelloWorld out.mp4",
 		"upgrade": "remotion upgrade",
 		"server": "ts-node server.tsx",
-		"test": "eslint 'src' --ext ts,tsx && tsc"
+		"test": "eslint 'src' --ext ts,tsx,js,jsx && tsc"
 	},
 	"repository": {},
 	"license": "UNLICENSED",

--- a/packages/docs/docs/jsx-support.md
+++ b/packages/docs/docs/jsx-support.md
@@ -1,0 +1,23 @@
+---
+id: javascript
+title: Plain Javascript
+---
+
+Since Remotion 1.3, you can opt out of Typescript and it's type checking advantages in Remotion. Continue at your own risk.
+
+## Opting out of Typescript
+
+You may import import `.js` and `.jsx` files as normal. If you would like to completely move to JS, rename `index.tsx` and `Video.tsx` so they have a `.jsx` file extension. Remove types such as `React.FC` and `SpringConfig`.
+
+## Upgrading
+
+If you upgrade from Remotion 1.2 or older, consider changing the `npm test` command to also include Javascript files, and to remove the `tsc` command:
+
+```diff
+-  "test": "eslint 'src' --ext ts,tsx && tsc"
++  "test": "eslint 'src' --ext ts,tsx,js,jsx"
+```
+
+## See also
+
+- [Custom Webpack config](webpack) for more advanced tweaking

--- a/packages/docs/sidebars.js
+++ b/packages/docs/sidebars.js
@@ -22,6 +22,7 @@ module.exports = {
         "fonts",
         "webpack",
         "use-img-and-iframe",
+        "javascript",
       ],
     },
     {

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -4,6 +4,44 @@ import { autoImports } from "./auto-import-rules";
 
 const baseExtends = ["eslint:recommended", "prettier"];
 
+const getRules = (typescript: boolean) => {
+  return {
+    ...xo.rules,
+    ...xoReact.rules,
+    "no-console": "off",
+    "10x/react-in-scope": "off",
+    "react/react-in-jsx-scope": "off",
+    "react/jsx-key": "off",
+    "react/jsx-no-target-blank": "off",
+    "react/jsx-tag-spacing": "off",
+    "react/prop-types": "off",
+    // The following rules are handled by typescript-eslint
+    ...(typescript
+      ? {
+          "no-unused-vars": "off",
+          "no-undef": "off",
+          "no-shadow": "off",
+          // Using `require` is useful for importing PNG sequences: require('frame' + frame + '.png')
+          "@typescript-eslint/no-var-requires": "off",
+        }
+      : {}),
+    // In Video.tsx we encourage using fragment for just a single composition
+    // since we intend to add more compositions later and you should then use a fragment.
+    "react/jsx-no-useless-fragment": "off",
+    // This is generally okay because on every frame, there will be a full rerender anyway!
+    "react/no-array-index-key": "off",
+    "10x/auto-import": [
+      "error",
+      {
+        imports: autoImports,
+      },
+    ],
+    // Enable Remotion specific rules
+    "@remotion/no-mp4-import": "warn",
+    "@remotion/warn-native-media-tag": "warn",
+  };
+};
+
 export = {
   env: {
     browser: true,
@@ -35,39 +73,10 @@ export = {
       files: ["*.{ts,tsx}"],
       extends: ["plugin:@typescript-eslint/recommended", ...baseExtends],
       parser: "@typescript-eslint/parser",
+      rules: getRules(true),
     },
   ],
-  rules: {
-    ...xo.rules,
-    ...xoReact.rules,
-    "no-console": "off",
-    "10x/react-in-scope": "off",
-    "react/react-in-jsx-scope": "off",
-    "react/jsx-key": "off",
-    "react/jsx-no-target-blank": "off",
-    "react/jsx-tag-spacing": "off",
-    "react/prop-types": "off",
-    // The following rules are handled by typescript-eslint
-    "no-unused-vars": "off",
-    "no-undef": "off",
-    "no-shadow": "off",
-    // In Video.tsx we encourage using fragment for just a single composition
-    // since we intend to add more compositions later and you should then use a fragment.
-    "react/jsx-no-useless-fragment": "off",
-    // This is generally okay because on every frame, there will be a full rerender anyway!
-    "react/no-array-index-key": "off",
-    "10x/auto-import": [
-      "error",
-      {
-        imports: autoImports,
-      },
-    ],
-    // Enable Remotion specific rules
-    "@remotion/no-mp4-import": "warn",
-    "@remotion/warn-native-media-tag": "warn",
-    // Using `require` is useful for importing PNG sequences: require('frame' + frame + '.png')
-    "@typescript-eslint/no-var-requires": "off",
-  },
+  rules: getRules(false),
   settings: {
     react: {
       version: "17.0.0",

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -2,6 +2,8 @@ import xo = require("eslint-config-xo/esnext");
 import xoReact = require("eslint-config-xo-react");
 import { autoImports } from "./auto-import-rules";
 
+const baseExtends = ["eslint:recommended", "prettier"];
+
 export = {
   env: {
     browser: true,
@@ -19,11 +21,7 @@ export = {
     "10x",
     "@remotion",
   ],
-  extends: [
-    "plugin:@typescript-eslint/recommended",
-    "eslint:recommended",
-    "prettier",
-  ].filter(Boolean),
+  extends: baseExtends,
   parser: "@typescript-eslint/parser",
   parserOptions: {
     ecmaVersion: 2020,
@@ -32,6 +30,13 @@ export = {
       jsx: true,
     },
   },
+  overrides: [
+    {
+      files: ["*.{ts,tsx}"],
+      extends: ["plugin:@typescript-eslint/recommended", ...baseExtends],
+      parser: "@typescript-eslint/parser",
+    },
+  ],
   rules: {
     ...xo.rules,
     ...xoReact.rules,

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -6,7 +6,7 @@
 	"private": true,
 	"scripts": {
 		"start": "npx ts-node ../cli/src/index.tsx preview src/index.tsx",
-		"test": "ts-unused-exports tsconfig.json && eslint 'src' --ext ts,tsx",
+		"test": "eslint 'src' --ext ts,tsx,js,jsx",
 		"build": "tsc -d",
 		"render": "remotion render src/index.tsx up video.mp4"
 	},

--- a/packages/example/src/CoinAnimation/index.tsx
+++ b/packages/example/src/CoinAnimation/index.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+import {
+	Img,
+	interpolate,
+	spring,
+	useCurrentFrame,
+	useVideoConfig,
+} from 'remotion';
 
 const CoinAnimation = () => {
 	const frame = useCurrentFrame();
@@ -48,7 +54,7 @@ const CoinAnimation = () => {
 				flex: 1,
 			}}
 		>
-			<img
+			<Img
 				src={getFrame(whichFrame)}
 				style={{
 					height: height / 2,

--- a/packages/example/src/Devices/Single.tsx
+++ b/packages/example/src/Devices/Single.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {useVideoConfig} from 'remotion';
+import {Img, useVideoConfig} from 'remotion';
 
 export const Single: React.FC<{
 	style: React.CSSProperties;
@@ -7,7 +7,7 @@ export const Single: React.FC<{
 }> = ({style, source}) => {
 	const videoConfig = useVideoConfig();
 	return (
-		<img
+		<Img
 			style={{
 				position: 'absolute',
 				transform: 'scale(0.5)',

--- a/packages/example/src/NewPackAnnouncement/index.tsx
+++ b/packages/example/src/NewPackAnnouncement/index.tsx
@@ -112,7 +112,7 @@ const Rating: React.FC = () => {
 					opacity: frame < 140 ? 0 : frame > 160 ? 1 : (frame - 140) / 20,
 				}}
 			>
-				<img
+				<Img
 					src="https://www.anysticker.app/logo-transparent.png"
 					style={{height: 200, width: 200, marginRight: 40}}
 				/>

--- a/packages/example/src/Up/index.tsx
+++ b/packages/example/src/Up/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+	Img,
 	interpolate,
 	spring,
 	SpringConfig,
@@ -59,7 +60,7 @@ const Up: React.FC<{
 			>
 				<Title line1={line1} line2={line2} />
 			</div>
-			<img
+			<Img
 				src={f}
 				style={{
 					transform: `translateY(${


### PR DESCRIPTION
- Tweak ESLint config to not apply Typescript rules to plain JS
- Document plain Javascript support and explain that you might have to remove types and adjust npm test command.

Relates to #52 