### PR TITLE
Spelling

### DIFF
--- a/packages/core/src/video/VideoForRendering.tsx
+++ b/packages/core/src/video/VideoForRendering.tsx
@@ -70,7 +70,7 @@ export const VideoForRendering: React.FC<AllowedVideoProps> = (props) => {
 
 	const onSetReadyState = useCallback(() => {
 		if (!videoRef.current) {
-			throw Error('No vide ref');
+			throw Error('No video ref');
 		}
 		if (videoRef.current.readyState === 4) {
 			setFrame();

--- a/packages/docs/blog/2021-02-13-remotion-1-2.md
+++ b/packages/docs/blog/2021-02-13-remotion-1-2.md
@@ -32,7 +32,7 @@ The terms of [the company license](https://github.com/JonnyBurger/remotion/blob/
 
 ## Roadmap
 
-A Github Project board has been setup with the goal [of indicating the next priorities](https://github.com/JonnyBurger/remotion/projects/3). Check it out!
+A GitHub Project board has been setup with the goal [of indicating the next priorities](https://github.com/JonnyBurger/remotion/projects/3). Check it out!
 
 ## Miscellaneous
 

--- a/packages/docs/docs/jsx-support.md
+++ b/packages/docs/docs/jsx-support.md
@@ -1,6 +1,6 @@
 ---
 id: javascript
-title: Plain Javascript
+title: Plain JavaScript
 ---
 
 Since Remotion 1.3, you can opt out of Typescript and it's type checking advantages in Remotion. Continue at your own risk.
@@ -11,7 +11,7 @@ You may import import `.js` and `.jsx` files as normal. If you would like to com
 
 ## Upgrading
 
-If you upgrade from Remotion 1.2 or older, consider changing the `npm test` command to also include Javascript files, and to remove the `tsc` command:
+If you upgrade from Remotion 1.2 or older, consider changing the `npm test` command to also include JavaScript files, and to remove the `tsc` command:
 
 ```diff
 -  "test": "eslint 'src' --ext ts,tsx && tsc"

--- a/packages/docs/docs/parametrized-rendering.md
+++ b/packages/docs/docs/parametrized-rendering.md
@@ -77,11 +77,11 @@ await renderFrames({
 });
 ```
 
-## Passing props in Github Actions
+## Passing props in GitHub Actions
 
-[See: Render using Github Actions](ssr#render-using-github-actions)
+[See: Render using GitHub Actions](ssr#render-using-github-actions)
 
-When using Github Actions, you need to adjust the file at `.github/workflows/render-video.yml` to make the inputs in the `workflow_dispatch` section manually match the shape of the props your root component accepts.
+When using GitHub Actions, you need to adjust the file at `.github/workflows/render-video.yml` to make the inputs in the `workflow_dispatch` section manually match the shape of the props your root component accepts.
 
 ```yml {3,7}
 workflow_dispatch:

--- a/packages/docs/docs/ssr.md
+++ b/packages/docs/docs/ssr.md
@@ -93,7 +93,7 @@ const start = async () => {
 start();
 ```
 
-[See also: Passing props in Github Actions](parametrized-rendering#passing-props-in-github-actions)
+[See also: Passing props in GitHub Actions](parametrized-rendering#passing-props-in-github-actions)
 
 ## Render using a HTTP server
 
@@ -116,13 +116,13 @@ docker build -t my-video .
 docker run -p 8000:8000 --privileged my-video
 ```
 
-## Render using Github Actions
+## Render using GitHub Actions
 
-The template includes a Github Actions workflow file
-under `.github/workflows/render-video.yml`. All you have to do is to adjust the props that your root component accepts in the workflow file and you can render a video right on Github.
+The template includes a GitHub Actions workflow file
+under `.github/workflows/render-video.yml`. All you have to do is to adjust the props that your root component accepts in the workflow file and you can render a video right on GitHub.
 
-1. Commit the template to a Github repository
-2. On Github, click the 'Actions' tab.
+1. Commit the template to a GitHub repository
+2. On GitHub, click the 'Actions' tab.
 3. Select the 'Render video' workflow on the left.
 4. A 'Run workflow' button should appear. Click it
 5. Fill in the props of the root component and click 'Run workflow'.
@@ -130,4 +130,4 @@ under `.github/workflows/render-video.yml`. All you have to do is to adjust the 
 
 Note that running the workflow may incur costs. However, the workflow will only run if you actively trigger it.
 
-[See also: Passing props in Github Actions](parametrized-rendering#passing-props-in-github-actions)
+[See also: Passing props in GitHub Actions](parametrized-rendering#passing-props-in-github-actions)

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -59,7 +59,7 @@ module.exports = {
               href: "https://twitter.com/JNYBGR",
             },
             {
-              label: "Github Issues",
+              label: "GitHub Issues",
               href: "https://github.com/JonnyBurger/remotion/issues",
             },
             {


### PR DESCRIPTION
<!--- 
  Please make sure to read CONTRIBUTING.md before sending a pull request.
  Thank you!
--->
Normally I offer a fancy explanation of what I did, but sadly, it appears that none of these items were flagged at the end.

`GitHub` and `JavaScript` are brands and have special casing rules (sadly, they both allow lowercase which confused my poor tool at the end).

`vide` is apparently a word that means `see!`, but I'm pretty sure you meant `video` :-)