### PR TITLE
Fixed remotion.config.ts typo

### DIFF
--- a/packages/docs/docs/config.md
+++ b/packages/docs/docs/config.md
@@ -10,7 +10,7 @@ You can control several behaviors of Remotion here.
 ```tsx
 import {Config} from 'remotion';
 
-Config.PixelFormat.setPixelFormat('yuv444p');
+Config.Output.setPixelFormat('yuv444p');
 ```
 
 ## Bundling

--- a/packages/example/remotion.config.ts
+++ b/packages/example/remotion.config.ts
@@ -1,9 +1,9 @@
 import {overrideWebpackConfig} from '@remotion/bundler';
 import {Config} from 'remotion';
 
-Config.Concurrency.setConcurrency(16);
+Config.Rendering.setConcurrency(16);
 Config.Output.setOverwriteOutput(true);
-Config.PixelFormat.setPixelFormat('yuv420p');
+Config.Output.setPixelFormat('yuv420p');
 
 overrideWebpackConfig((currentConfiguration) => {
 	return {


### PR DESCRIPTION
Fixing typo on remotion.config.js which was causing `render` to fail
