### PR TITLE
fix (maybe) typo in docs

### DIFF
--- a/packages/docs/docs/jsx-support.md
+++ b/packages/docs/docs/jsx-support.md
@@ -7,7 +7,7 @@ Since Remotion 1.3, you can opt out of Typescript and it's type checking advanta
 
 ## Opting out of Typescript
 
-You may import import `.js` and `.jsx` files as normal. If you would like to completely move to JS, rename `index.tsx` and `Video.tsx` so they have a `.jsx` file extension. Remove types such as `React.FC` and `SpringConfig`.
+You may import `.js` and `.jsx` files as normal. If you would like to completely move to JS, rename `index.tsx` and `Video.tsx` so they have a `.jsx` file extension. Remove types such as `React.FC` and `SpringConfig`.
 
 ## Upgrading
 


### PR DESCRIPTION
I'm not sure if this is a typo. But if it is, here is a PR to fix it!
On the [docs-page](https://www.remotion.dev/docs/javascript/) for JavaScript is written `You may import import ...` so I 'fixed' it and deleted the second `import`.