### PR TITLE
fixing wrong variable in the Error message

### DIFF
--- a/packages/core/src/Composition.tsx
+++ b/packages/core/src/Composition.tsx
@@ -55,7 +55,7 @@ export const Composition = <T,>({
 		}
 		if (!id.match(/^([a-zA-Z0-9-])+$/g)) {
 			throw new Error(
-				`Composition id can only contain a-z, A-Z, 0-9 and -. You passed ${name}`
+				`Composition id can only contain a-z, A-Z, 0-9 and -. You passed ${id}`
 			);
 		}
 		registerComposition<T>({


### PR DESCRIPTION
As above, there was a name, but it should be id.

