### PR TITLE
fix(render): use queue instead of stack for resources and waiters

### DIFF
--- a/packages/renderer/src/pool.ts
+++ b/packages/renderer/src/pool.ts
@@ -8,7 +8,7 @@ export class Pool<T> {
   }
 
   acquire(): Promise<T> {
-    const resource = this.resources.pop();
+    const resource = this.resources.shift();
     if (resource !== undefined) {
       return Promise.resolve(resource);
     } else {
@@ -21,7 +21,7 @@ export class Pool<T> {
   }
 
   release(resource: T): void {
-    const waiter = this.waiters.pop();
+    const waiter = this.waiters.shift();
     if (waiter !== undefined) {
       waiter(resource);
     } else {


### PR DESCRIPTION
I work on gifs and I figured out that frames render from end to start, because i use stack in pool
that affect render video perf and maybe something else 

fix it
