### PR TITLE
fix: mark onProgressUpdate as optional in bundle

### DIFF
--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -13,7 +13,7 @@ const promisified = promisify(webpack);
 
 export const bundle = async (
 	entryPoint: string,
-	onProgressUpdate: (f: number) => void,
+	onProgressUpdate?: (f: number) => void,
 	options?: {
 		webpackOverride?: WebpackOverrideFn;
 	}


### PR DESCRIPTION
Hi! 👋🏽 

This fixes a current small issue where TypeScript doesn't compile `server.tsx` when running `npm run server` because the types don't match - `bundle` requires two arguments currently.

## Steps to reproduce

- Run `yarn create video`;
- Run `yarn server`;