### PR TITLE
feat: improve keyboard navigation

### DIFF
--- a/packages/cli/src/editor/components/CheckboardToggle.tsx
+++ b/packages/cli/src/editor/components/CheckboardToggle.tsx
@@ -3,6 +3,7 @@ import {
 	CheckerboardContext,
 	persistCheckerboardOption,
 } from '../state/checkerboard';
+import {ControlButton} from './ControlButton';
 
 export const CheckboardToggle: React.FC = () => {
 	const {checkerboard, setCheckerboard} = useContext(CheckerboardContext);
@@ -15,15 +16,9 @@ export const CheckboardToggle: React.FC = () => {
 	}, [setCheckerboard]);
 
 	return (
-		<div
-			role="button"
-			title="Show transparency as checkerboard"
+		<ControlButton
+			aria-label="Show transparency as checkerboard"
 			onClick={onClick}
-			style={{
-				userSelect: 'none',
-				display: 'inline',
-				height: 16,
-			}}
 		>
 			<svg
 				aria-hidden="true"
@@ -41,6 +36,6 @@ export const CheckboardToggle: React.FC = () => {
 					d="M480 0H32A32 32 0 0 0 0 32v448a32 32 0 0 0 32 32h448a32 32 0 0 0 32-32V32a32 32 0 0 0-32-32zm-32 256H256v192H64V256h192V64h192z"
 				/>
 			</svg>
-		</div>
+		</ControlButton>
 	);
 };

--- a/packages/cli/src/editor/components/CompositionSelector.tsx
+++ b/packages/cli/src/editor/components/CompositionSelector.tsx
@@ -63,8 +63,10 @@ export const CompositionSelector: React.FC = () => {
 					return (
 						<Item
 							key={c.id}
+							href={c.id}
 							selected={currentComposition === c.id}
-							onClick={() => {
+							onClick={(evt) => {
+								evt.preventDefault();
 								selectComposition(c);
 							}}
 						>

--- a/packages/cli/src/editor/components/ControlButton.tsx
+++ b/packages/cli/src/editor/components/ControlButton.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const ControlButton = styled.button`
+	opacity: ${(p) => (p.disabled ? 0.5 : 1)};
+	display: inline-flex;
+	background: none;
+	border: none;
+	padding: 0;
+`;

--- a/packages/cli/src/editor/components/PlayPause.tsx
+++ b/packages/cli/src/editor/components/PlayPause.tsx
@@ -5,6 +5,7 @@ import {Play} from '../icons/play';
 import {StepBack} from '../icons/step-back';
 import {StepForward} from '../icons/step-forward';
 import {getLastFrames, setLastFrames} from '../state/last-frames';
+import {ControlButton} from './ControlButton';
 
 export const PlayPause: React.FC = () => {
 	const [playing, setPlaying] = Internals.Timeline.usePlayingState();
@@ -125,13 +126,10 @@ export const PlayPause: React.FC = () => {
 
 	return (
 		<>
-			<div
+			<ControlButton
+				aria-label="Step back one frame"
+				disabled={frame === 0}
 				onClick={frameBack}
-				style={{
-					display: 'inline-flex',
-					opacity: frame === 0 ? 0.5 : 1,
-					userSelect: 'none',
-				}}
 			>
 				<StepBack
 					style={{
@@ -140,16 +138,12 @@ export const PlayPause: React.FC = () => {
 						color: 'white',
 					}}
 				/>
-			</div>
+			</ControlButton>
 			<div style={{width: 10}} />
-			<div
+			<ControlButton
+				aria-label={playing ? 'Pause' : 'Play'}
+				disabled={Boolean(video)}
 				onClick={toggle}
-				title={playing ? 'Pause' : 'Play'}
-				style={{
-					display: 'inline-flex',
-					opacity: video ? 1 : 0.5,
-					userSelect: 'none',
-				}}
 			>
 				{playing ? (
 					<Pause
@@ -168,15 +162,12 @@ export const PlayPause: React.FC = () => {
 						}}
 					/>
 				)}
-			</div>
+			</ControlButton>
 			<div style={{width: 10}} />
-			<div
+			<ControlButton
+				aria-label="Step forward one frame"
+				disabled={isLastFrame}
 				onClick={frameForward}
-				style={{
-					display: 'inline-flex',
-					opacity: isLastFrame ? 0.5 : 1,
-					userSelect: 'none',
-				}}
 			>
 				<StepForward
 					style={{
@@ -185,7 +176,7 @@ export const PlayPause: React.FC = () => {
 						color: 'white',
 					}}
 				/>
-			</div>
+			</ControlButton>
 		</>
 	);
 };

--- a/packages/cli/src/editor/components/SizeSelector.tsx
+++ b/packages/cli/src/editor/components/SizeSelector.tsx
@@ -13,7 +13,11 @@ export const SizeSelector: React.FC = () => {
 
 	return (
 		<div>
-			<select onChange={onChange} value={size}>
+			<select
+				aria-label="Select the size of the preview"
+				onChange={onChange}
+				value={size}
+			>
 				<option value="auto">Fit</option>
 				<option value="0.25">25%</option>
 				<option value="0.5">50%</option>


### PR DESCRIPTION
Hi! 👋🏽 

The current implementation, using `div`s, prevents better keyboard navigation - we can't tab through the list of compositions or interact with the buttons without using the arrow keys.

This PR improves keyboard navigation by using `button` tags were applicable and adding the `href` attribute to the `a` tags of compositions.

While implementing these changes, I wondered if it'd interesting to try and add `react-router-dom` or something similar to implement actual navigation in React.