### PR TITLE
Add support to use requestAnimationFrame for render frames in preview

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
 	"scripts": {
 		"test": "eslint src --ext ts,tsx",
 		"build": "tsc -d && node add-bin.js",
-		"dev": "ts-node src/preview.ts x ../example/index.tsx"
+		"dev": "ts-node src/preview.ts x ../example/src/index.tsx"
 	},
 	"files": [
 		"dist",


### PR DESCRIPTION
This PR adds option to use `requestAnimationFrame` for play frames instead of `setTimeout`.

It was just an idea but it improves FPS greatly, especially effective for BetaText in examples.