### PR TITLE
Fix bugs in getTimelineClipName

### DIFF
--- a/packages/core/src/get-timeline-clip-name.ts
+++ b/packages/core/src/get-timeline-clip-name.ts
@@ -1,14 +1,19 @@
-export const getTimelineClipName = (children: any, i = 0): string => {
-	const arrays = Array.isArray(children) ? children : [children];
-	const tree = arrays.map((ch) => {
+import {Children, isValidElement} from 'react';
+
+export const getTimelineClipName = (
+	children: React.ReactNode,
+	i = 0
+): string => {
+	const tree = Children.map(children, (ch) => {
+		if (!isValidElement(ch)) return '';
 		// Must be name, not ID
-		const name = ch?.type?.name;
-		const root = name ? (('  '.repeat(i) + name) as string) : null;
-		if (ch?.props.children) {
-			const chName = getTimelineClipName(children.props.children, i + 1);
+		const name = typeof ch.type !== 'string' && ch.type.name;
+		const root = name ? '  '.repeat(i) + name : null;
+		if (ch.props.children) {
+			const chName = getTimelineClipName(ch.props.children, i + 1);
 			return [root, chName].filter(Boolean).join('\n');
 		}
 		return root;
 	});
-	return tree.filter(Boolean).join('\n');
+	return tree ? tree.filter(Boolean).join('\n') : '';
 };


### PR DESCRIPTION
Fixed potential bugs in getTimelineClipName, one of them I found is `<Sequence><p>some text</p></Sequence>` will crash