### PR TITLE
Webpack caching

### DIFF
--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -25,6 +25,7 @@ export const bundle = async (
 	options?: {
 		webpackOverride?: WebpackOverrideFn;
 		outDir?: string;
+		enableCaching?: boolean;
 	}
 ): Promise<string> => {
 	const outDir = await prepareOutDir(options?.outDir ?? null);
@@ -37,6 +38,8 @@ export const bundle = async (
 			webpackOverride:
 				options?.webpackOverride ?? Internals.getWebpackOverrideFn(),
 			onProgressUpdate,
+			enableCaching:
+				options?.enableCaching ?? Internals.DEFAULT_WEBPACK_CACHE_ENABLED,
 		}),
 	]);
 	if (!output) {

--- a/packages/bundler/src/index.ts
+++ b/packages/bundler/src/index.ts
@@ -68,4 +68,5 @@ export const startServer = async (
 };
 
 export * from './bundler';
+export {cacheExists} from './webpack-cache';
 export {overrideWebpackConfig};

--- a/packages/bundler/src/index.ts
+++ b/packages/bundler/src/index.ts
@@ -68,5 +68,5 @@ export const startServer = async (
 };
 
 export * from './bundler';
-export {cacheExists} from './webpack-cache';
+export {cacheExists, clearCache} from './webpack-cache';
 export {overrideWebpackConfig};

--- a/packages/bundler/src/webpack-cache.ts
+++ b/packages/bundler/src/webpack-cache.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import path from 'path';
+
+type Environment = 'development' | 'production';
+
+declare global {
+	// eslint-disable-next-line @typescript-eslint/no-namespace
+	namespace NodeJS {
+		interface ProcessVersions {
+			pnp?: string;
+		}
+	}
+}
+
+// Inlined from https://github.com/webpack/webpack/blob/4c2ee7a4ddb8db2362ca83b6c4190523387ba7ee/lib/config/defaults.js#L265
+// An algorithm to determine where Webpack will cache the depencies
+export const getWebpackCacheDir = () => {
+	const cwd = process.cwd();
+	let dir: string | undefined = cwd;
+	for (;;) {
+		try {
+			if (fs.statSync(path.join(dir, 'package.json')).isFile()) break;
+			// eslint-disable-next-line no-empty
+		} catch (e) {}
+		const parent = path.dirname(dir);
+		if (dir === parent) {
+			dir = undefined;
+			break;
+		}
+		dir = parent;
+	}
+	if (!dir) {
+		return path.resolve(cwd, '.cache/webpack');
+	} else if (process.versions.pnp === '1') {
+		return path.resolve(dir, '.pnp/.cache/webpack');
+	} else if (process.versions.pnp === '3') {
+		return path.resolve(dir, '.yarn/.cache/webpack');
+	} else {
+		return path.resolve(dir, 'node_modules/.cache/webpack');
+	}
+};
+
+export const getWebpackCacheName = (environment: Environment) => {
+	return `remotion-${environment}`;
+};
+
+export const cacheExists = (environment: Environment) => {
+	return fs.existsSync(
+		path.join(getWebpackCacheDir(), getWebpackCacheName(environment))
+	);
+};

--- a/packages/bundler/src/webpack-cache.ts
+++ b/packages/bundler/src/webpack-cache.ts
@@ -40,12 +40,20 @@ export const getWebpackCacheDir = () => {
 	}
 };
 
+const remotionCacheLocation = (environment: Environment) => {
+	return path.join(getWebpackCacheDir(), getWebpackCacheName(environment));
+};
+
+export const clearCache = (environment: Environment) => {
+	return fs.promises.rmdir(remotionCacheLocation(environment), {
+		recursive: true,
+	});
+};
+
 export const getWebpackCacheName = (environment: Environment) => {
 	return `remotion-${environment}`;
 };
 
 export const cacheExists = (environment: Environment) => {
-	return fs.existsSync(
-		path.join(getWebpackCacheDir(), getWebpackCacheName(environment))
-	);
+	return fs.existsSync(remotionCacheLocation(environment));
 };

--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import {WebpackConfiguration, WebpackOverrideFn} from 'remotion';
 import webpack, {ProgressPlugin} from 'webpack';
+import {getWebpackCacheName} from './webpack-cache';
 
 const ErrorOverlayPlugin = require('@webhotelier/webpack-fast-refresh/error-overlay');
 const ReactRefreshPlugin = require('@webhotelier/webpack-fast-refresh');
@@ -26,6 +27,7 @@ export const webpackConfig = ({
 	environment,
 	webpackOverride = (f) => f,
 	onProgressUpdate,
+	enableCaching = true,
 }: {
 	entry: string;
 	userDefinedComponent: string;
@@ -33,6 +35,7 @@ export const webpackConfig = ({
 	environment: 'development' | 'production';
 	webpackOverride?: WebpackOverrideFn;
 	onProgressUpdate?: (f: number) => void;
+	enableCaching?: boolean;
 }): WebpackConfiguration => {
 	return webpackOverride({
 		optimization: {
@@ -46,6 +49,12 @@ export const webpackConfig = ({
 							entries: false,
 					  },
 		},
+		cache: enableCaching
+			? {
+					type: 'filesystem',
+					name: getWebpackCacheName(environment),
+			  }
+			: false,
 		devtool: 'cheap-module-source-map',
 		entry: [
 			environment === 'development'

--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import {WebpackConfiguration, WebpackOverrideFn} from 'remotion';
+import {Internals, WebpackConfiguration, WebpackOverrideFn} from 'remotion';
 import webpack, {ProgressPlugin} from 'webpack';
 import {getWebpackCacheName} from './webpack-cache';
 
@@ -27,7 +27,7 @@ export const webpackConfig = ({
 	environment,
 	webpackOverride = (f) => f,
 	onProgressUpdate,
-	enableCaching = true,
+	enableCaching = Internals.DEFAULT_WEBPACK_CACHE_ENABLED,
 }: {
 	entry: string;
 	userDefinedComponent: string;

--- a/packages/cli/src/parse-command-line.ts
+++ b/packages/cli/src/parse-command-line.ts
@@ -12,6 +12,7 @@ export type CommandLineOptions = {
 	['browser-executable']: BrowserExecutable;
 	['pixel-format']: PixelFormat;
 	['image-format']: ImageFormat;
+	['bundle-cache']: string;
 	codec: Codec;
 	concurrency: number;
 	config: string;
@@ -36,6 +37,11 @@ export const parseCommandLine = () => {
 	}
 	if (parsedCli['browser-executable']) {
 		Config.Puppeteer.setBrowserExecutable(parsedCli['browser-executable']);
+	}
+	if (typeof parsedCli['bundle-cache'] !== 'undefined') {
+		Config.Bundling.setCachingEnabled(
+			parsedCli['bundle-cache'] === 'false' ? false : true
+		);
 	}
 	if (parsedCli.concurrency) {
 		Config.Rendering.setConcurrency(parsedCli.concurrency);

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -1,4 +1,4 @@
-import {bundle, cacheExists} from '@remotion/bundler';
+import {bundle, cacheExists, clearCache} from '@remotion/bundler';
 import {
 	ensureLocalBrowser,
 	ffmpegHasFeature,
@@ -140,11 +140,22 @@ export const render = async () => {
 		cliProgress.Presets.shades_grey
 	);
 
+	const shouldCache = Internals.getWebpackCaching();
 	const cacheExistedBefore = cacheExists('production');
+	if (cacheExistedBefore && !shouldCache) {
+		await clearCache('production');
+		console.log('🧹 Cache disabled but found. Deleting...');
+	}
 	bundlingProgress.start(100, 0);
-	const bundled = await bundle(fullPath, (progress) => {
-		bundlingProgress.update(progress);
-	});
+	const bundled = await bundle(
+		fullPath,
+		(progress) => {
+			bundlingProgress.update(progress);
+		},
+		{
+			enableCaching: shouldCache,
+		}
+	);
 	bundlingProgress.stop();
 	const cacheExistedAfter = cacheExists('production');
 	if (cacheExistedAfter && !cacheExistedBefore) {

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -143,8 +143,9 @@ export const render = async () => {
 	const shouldCache = Internals.getWebpackCaching();
 	const cacheExistedBefore = cacheExists('production');
 	if (cacheExistedBefore && !shouldCache) {
+		process.stdout.write('🧹 Cache disabled but found. Deleting... ');
 		await clearCache('production');
-		console.log('🧹 Cache disabled but found. Deleting...');
+		process.stdout.write('done. \n');
 	}
 	bundlingProgress.start(100, 0);
 	const bundled = await bundle(

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -1,4 +1,4 @@
-import {bundle} from '@remotion/bundler';
+import {bundle, cacheExists} from '@remotion/bundler';
 import {
 	ensureLocalBrowser,
 	ffmpegHasFeature,
@@ -140,12 +140,16 @@ export const render = async () => {
 		cliProgress.Presets.shades_grey
 	);
 
+	const cacheExistedBefore = cacheExists('production');
 	bundlingProgress.start(100, 0);
-
 	const bundled = await bundle(fullPath, (progress) => {
 		bundlingProgress.update(progress);
 	});
 	bundlingProgress.stop();
+	const cacheExistedAfter = cacheExists('production');
+	if (cacheExistedAfter && !cacheExistedBefore) {
+		console.log('⚡️ Cached bundle. Subsequent builds will be faster.');
+	}
 	const comps = await getCompositions(
 		bundled,
 		Internals.getBrowser() ?? Internals.DEFAULT_BROWSER

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -14,6 +14,7 @@ import {
 import {setOverwriteOutput} from './overwrite';
 import {PixelFormat, setPixelFormat} from './pixel-format';
 import {setQuality} from './quality';
+import {setWebpackCaching} from './webpack-caching';
 
 export const Config = {
 	Bundling: {
@@ -23,6 +24,11 @@ export const Config = {
 		 * Docs: http://remotion.dev/docs/webpack
 		 */
 		overrideWebpackConfig,
+		/**
+		 * Whether Webpack bundles should be cached to make
+		 * subsequent renders faster. Default: true
+		 */
+		setCachingEnabled: setWebpackCaching,
 	},
 	Puppeteer: {
 		/**

--- a/packages/core/src/config/webpack-caching.ts
+++ b/packages/core/src/config/webpack-caching.ts
@@ -1,0 +1,14 @@
+export const DEFAULT_WEBPACK_CACHE_ENABLED = true;
+
+let webpackCaching = DEFAULT_WEBPACK_CACHE_ENABLED;
+
+export const setWebpackCaching = (flag: boolean) => {
+	if (typeof flag !== 'boolean') {
+		throw new TypeError('Caching flag must be a boolean.');
+	}
+	webpackCaching = flag;
+};
+
+export const getWebpackCaching = () => {
+	return webpackCaching;
+};

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -42,6 +42,10 @@ import {
 	validateSelectedPixelFormatAndCodecCombination,
 } from './config/pixel-format';
 import {getQuality} from './config/quality';
+import {
+	DEFAULT_WEBPACK_CACHE_ENABLED,
+	getWebpackCaching,
+} from './config/webpack-caching';
 import * as perf from './perf';
 import {getCompositionName, getIsEvaluation, getRoot} from './register-root';
 import {RemotionRoot} from './RemotionRoot';
@@ -75,6 +79,7 @@ export const Internals = {
 	DEFAULT_CODEC,
 	DEFAULT_PIXEL_FORMAT,
 	FEATURE_FLAG_FIREFOX_SUPPORT,
+	DEFAULT_WEBPACK_CACHE_ENABLED,
 	getBrowser,
 	DEFAULT_BROWSER,
 	getDefaultCrfForCodec,
@@ -84,6 +89,7 @@ export const Internals = {
 	validateSelectedPixelFormatAndImageFormatCombination,
 	validateSelectedPixelFormatAndCodecCombination,
 	validateFrameRange,
+	getWebpackCaching,
 };
 
 export type {

--- a/packages/docs/docs/cli.md
+++ b/packages/docs/docs/cli.md
@@ -24,7 +24,8 @@ Besides choosing a video and output location with the command line arguments, th
 - `--codec`: [`h264` or `h265` or `png` or `vp8` or `vp9`](/docs/config#setoutputformat). If you don't supply `--codec`, it will use the H.264 encoder. Available since v1.4.
 - `--crf`: [To set Constant Rate Factor (CRF) of the output](/docs/config#setcrf). Minimum 0. Use this rate control mode if you want to keep the best quality and care less about the file size. Available since v1.4.
 - `--browser-executable`: [Path to a Chrome executable](/docs/config#setbrowserexecutable). If not specified and Remotion cannot find one, it will download one during rendering. Available since v1.5.
-- `--frames`: [Render a still frame or a subset of a video](/docs/config#setframerange). Example: `--frames=0-9` (To select the first 10 frames) or <br/> `--frames=50` (To render a still of the 51st frame).
+- `--frames`: [Render a still frame or a subset of a video](/docs/config#setframerange). Example: `--frames=0-9` (To select the first 10 frames) or `--frames=50` (To render a still of the 51st frame). Available since v2.0.
+- `--bundle-cache`: [Enable or disable Webpack caching](/docs/config#setcachingenabled). This flag is enabled by default, use `--bundle-cache=false` to disable caching. Available since v2.0.
 
 :::info
 If you don't feel like passing command line flags every time, consider creating a `remotion.config.ts` [config file](/docs/config).

--- a/packages/docs/docs/config.md
+++ b/packages/docs/docs/config.md
@@ -33,7 +33,7 @@ Config.Bundling.overrideWebpackConfig((currentConfiguration) => {
 
 _Available from Version 2.0._
 
-Enable or disable webpack caching. Default is `true` which will make the Webpack step in the first run a bit slower but will massively speed up subsequent runs. We recommend to keep this option always true and encourage to report issues on Github.
+Enable or disable webpack caching. Default is `true` which will make the Webpack step in the first run a bit slower but will massively speed up subsequent runs. We recommend to keep this option enabled in all cases and encourage to report issues on Github if you encounter some.
 
 ```tsx
 Config.Bundling.setCachingEnabled(false);

--- a/packages/docs/docs/config.md
+++ b/packages/docs/docs/config.md
@@ -19,6 +19,8 @@ Config.Output.setCodec('h265');
 
 ### overrideWebpackConfig()
 
+_Available from Version 1.1._
+
 Allows you to insert your custom Webpack config. [See the page about custom Webpack configs](/docs/webpack) for more information.
 
 ```tsx
@@ -26,6 +28,18 @@ Config.Bundling.overrideWebpackConfig((currentConfiguration) => {
   // Return a new Webpack configuration
 });
 ```
+
+### setCachingEnabled()
+
+_Available from Version 2.0._
+
+Enable or disable webpack caching. Default is `true` which will make the Webpack step in the first run a bit slower but will massively speed up subsequent runs. We recommend to keep this option always true and encourage to report issues on Github.
+
+```tsx
+Config.Bundling.setCachingEnabled(false);
+```
+
+The [command line flag](/docs/cli) `--bundle-cache` will take precedence over this option.
 
 ## Puppeteer
 


### PR DESCRIPTION
This will enable Webpack caching *by default*. It slows down the first bundling a little bit but makes subsequent builds 4-5x faster even when you make changes. It should be desirable in all cases, but there is still a way to disable it.

Reviews and feedback from the community appreciated!

Fixes #87 