### PR TITLE
fix: properly restart video in development mode

### DIFF
--- a/packages/core/src/video/VideoForDevelopment.tsx
+++ b/packages/core/src/video/VideoForDevelopment.tsx
@@ -22,11 +22,19 @@ export const VideoForDevelopment: React.FC<RemotionVideoProps> = (props) => {
 		if (!videoRef.current) {
 			throw new Error('No video ref found');
 		}
+
 		if (!videoConfig) {
 			throw new Error('No video config found');
 		}
-		if (!playing || currentFrame === 0) {
+
+		if (!playing) {
 			videoRef.current.currentTime = currentFrame / (1000 / videoConfig.fps);
+			return;
+		}
+
+		if (currentFrame === 0 && playing) {
+			videoRef.current.currentTime = 0;
+			videoRef.current?.play();
 		}
 	}, [currentFrame, playing, videoConfig]);
 

--- a/packages/example/src/Features/index.tsx
+++ b/packages/example/src/Features/index.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import {Video} from 'remotion';
 
-const Features = () => {
+const Features: React.FC = () => {
 	const tray = require('./tray.webm');
 	const watermelon = require('./watermelon.webm');
 	const textstickers = require('./textstickers.webm');


### PR DESCRIPTION
Hi! 👋🏽 

There's currently a bug in the `Video` component in development:

When playing in loop, the `video` doesn't restart correctly after its first run. It's reproducible in the `features` example:

https://user-images.githubusercontent.com/13774309/110224449-fcd9c580-7edb-11eb-9b4c-2e47ae7b412f.mp4

That's because, after setting the `currentTime` to `0`, we need to play the video again.

This PR tries to fix this behaviour:

https://user-images.githubusercontent.com/13774309/110224518-afaa2380-7edc-11eb-8bb7-18fbaf31493b.mp4

Let me know if you have any suggestions or find any bugs.