### PR TITLE
fix img and video delayrender bugs

### DIFF
--- a/packages/core/src/Img.tsx
+++ b/packages/core/src/Img.tsx
@@ -1,4 +1,4 @@
-import React, {forwardRef, useCallback, useState} from 'react';
+import React, {forwardRef, useCallback, useEffect, useState} from 'react';
 import {continueRender, delayRender} from './ready-manager';
 
 const ImgRefForwarding: React.ForwardRefRenderFunction<
@@ -9,6 +9,15 @@ const ImgRefForwarding: React.ForwardRefRenderFunction<
 	>
 > = ({onLoad, onError, ...props}, ref) => {
 	const [handle] = useState(() => delayRender());
+
+	useEffect(() => {
+		if (
+			ref &&
+			(ref as React.MutableRefObject<HTMLImageElement>).current.complete
+		) {
+			continueRender(handle);
+		}
+	}, [handle, ref]);
 
 	const didLoad = useCallback(
 		(e: React.SyntheticEvent<HTMLImageElement, Event>) => {

--- a/packages/core/src/video/VideoForRendering.tsx
+++ b/packages/core/src/video/VideoForRendering.tsx
@@ -23,6 +23,10 @@ export const VideoForRendering: React.FC<RemotionVideoProps> = ({
 		const frameInSeconds = frame / videoConfig.fps;
 		const handle = delayRender();
 		if (videoRef.current.currentTime === frameInSeconds) {
+			if (videoRef.current.readyState >= 2) {
+				continueRender(handle);
+				return;
+			}
 			videoRef.current.addEventListener(
 				'loadeddata',
 				() => {


### PR DESCRIPTION
I noticed that img and video tags don't call onLoad() or loadeddata tags respectively if the assets are already in the browser cache. fixing this