### PR TITLE
fix(preview): increase buttons size

### DIFF
--- a/packages/cli/src/editor/components/ControlButton.tsx
+++ b/packages/cli/src/editor/components/ControlButton.tsx
@@ -5,5 +5,5 @@ export const ControlButton = styled.button`
 	display: inline-flex;
 	background: none;
 	border: none;
-	padding: 0;
+	padding: 6px;
 `;

--- a/packages/cli/src/editor/components/ControlButton.tsx
+++ b/packages/cli/src/editor/components/ControlButton.tsx
@@ -1,9 +1,11 @@
 import styled from 'styled-components';
 
+export const CONTROL_BUTTON_PADDING = 6;
+
 export const ControlButton = styled.button`
 	opacity: ${(p) => (p.disabled ? 0.5 : 1)};
 	display: inline-flex;
 	background: none;
 	border: none;
-	padding: 6px;
+	padding: ${CONTROL_BUTTON_PADDING}px;
 `;

--- a/packages/cli/src/editor/components/PlayPause.tsx
+++ b/packages/cli/src/editor/components/PlayPause.tsx
@@ -136,7 +136,7 @@ export const PlayPause: React.FC = () => {
 					}}
 				/>
 			</ControlButton>
-			<div style={{width: 10}} />
+			
 			<ControlButton
 				aria-label={playing ? 'Pause' : 'Play'}
 				disabled={!video}
@@ -160,7 +160,7 @@ export const PlayPause: React.FC = () => {
 					/>
 				)}
 			</ControlButton>
-			<div style={{width: 10}} />
+
 			<ControlButton
 				aria-label="Step forward one frame"
 				disabled={isLastFrame}

--- a/packages/cli/src/editor/components/PreviewToolbar.tsx
+++ b/packages/cli/src/editor/components/PreviewToolbar.tsx
@@ -8,23 +8,17 @@ const Container = styled.div`
 	display: flex;
 	justify-content: center;
 	border-top: 1px solid rgba(0, 0, 0, 0.5);
-	padding-top: 8px;
-	padding-bottom: 8px;
+	padding-top: 2px;
+	padding-bottom: 2px;
 	align-items: center;
 	flex-direction: row;
-`;
-
-const Spacer = styled.div`
-	width: 12px;
 `;
 
 export const PreviewToolbar: React.FC = () => {
 	return (
 		<Container>
 			<SizeSelector />
-			<Spacer />
 			<PlayPause />
-			<div style={{width: 10}} />
 			<CheckboardToggle />
 		</Container>
 	);

--- a/packages/cli/src/editor/components/SizeSelector.tsx
+++ b/packages/cli/src/editor/components/SizeSelector.tsx
@@ -1,5 +1,6 @@
-import React, {useCallback, useContext} from 'react';
+import React, {useCallback, useContext, useMemo} from 'react';
 import {PreviewSize, PreviewSizeContext} from '../state/preview-size';
+import {CONTROL_BUTTON_PADDING} from './ControlButton';
 
 export const SizeSelector: React.FC = () => {
 	const {size, setSize} = useContext(PreviewSizeContext);
@@ -11,8 +12,14 @@ export const SizeSelector: React.FC = () => {
 		[setSize]
 	);
 
+	const style = useMemo(() => {
+		return {
+			padding: CONTROL_BUTTON_PADDING,
+		};
+	}, []);
+
 	return (
-		<div style={{padding: 6}}>
+		<div style={style}>
 			<select
 				aria-label="Select the size of the preview"
 				onChange={onChange}

--- a/packages/cli/src/editor/components/SizeSelector.tsx
+++ b/packages/cli/src/editor/components/SizeSelector.tsx
@@ -12,7 +12,7 @@ export const SizeSelector: React.FC = () => {
 	);
 
 	return (
-		<div>
+		<div style={{padding: 6}}>
 			<select
 				aria-label="Select the size of the preview"
 				onChange={onChange}


### PR DESCRIPTION
Hello, i'm back with small improvements

in this pr I increased preview toolbar buttons size, bc it is so hard to click on `15x15px` button

<details>
    <summary>before</summary>
   
<img width="265" alt="Снимок экрана 2021-03-12 в 13 17 50" src="https://user-images.githubusercontent.com/6726016/110926768-daa9d280-8335-11eb-846b-efcf8eaf5ad5.png">

</details>

<details >
    <summary>after</summary>
   
<img width="295" alt="Снимок экрана 2021-03-12 в 13 17 17" src="https://user-images.githubusercontent.com/6726016/110926809-e5fcfe00-8335-11eb-8a47-a0be3b740df4.png">


</details>