### PR TITLE
Improve testing (core)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,20 +12,16 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 
 ### Code setup
 
-You can clone this repo and run
+Clone the repo and run
 
 ```console
-npm i && npx lerna bootstrap
-```
-
-to set up the project.
-To rebuild the project, run
-
-```console
+npm i
+npx lerna bootstrap
 npm run build
+npx lerna bootstrap
 ```
 
-from the root.
+to set up the project. Make sure to run `npx lerna bootstrap` twice - the reason is that during the build phase new CLI binaries are being created so another symlink is necessary. You only have to do this once.
 
 We recommend keeping a terminal open with the command
 

--- a/packages/core/src/config/crf.ts
+++ b/packages/core/src/config/crf.ts
@@ -60,5 +60,11 @@ export const validateSelectedCrfAndCodecCombination = (
 };
 
 export const getActualCrf = (codec: Codec) => {
-	return getCrfOrUndefined() ?? getDefaultCrfForCodec(codec);
+	try {
+		const crf = getCrfOrUndefined() ?? getDefaultCrfForCodec(codec);
+		validateSelectedCrfAndCodecCombination(crf, codec);
+		return crf;
+	} catch (e) {
+		return getDefaultCrfForCodec(codec);
+	}
 };

--- a/packages/core/src/config/crf.ts
+++ b/packages/core/src/config/crf.ts
@@ -60,11 +60,7 @@ export const validateSelectedCrfAndCodecCombination = (
 };
 
 export const getActualCrf = (codec: Codec) => {
-	try {
-		const crf = getCrfOrUndefined() ?? getDefaultCrfForCodec(codec);
-		validateSelectedCrfAndCodecCombination(crf, codec);
-		return crf;
-	} catch (e) {
-		return getDefaultCrfForCodec(codec);
-	}
+	const crf = getCrfOrUndefined() ?? getDefaultCrfForCodec(codec);
+	validateSelectedCrfAndCodecCombination(crf, codec);
+	return crf;
 };

--- a/packages/core/src/config/frame-range.ts
+++ b/packages/core/src/config/frame-range.ts
@@ -92,7 +92,7 @@ export const setFrameRangeFromCli = (newFrameRange: string | number) => {
 			);
 		}
 		for (const value of parsed) {
-			if (typeof value !== 'number') {
+			if (isNaN(value)) {
 				throw new Error(
 					'--frames flag must be a single number, or 2 numbers separated by `-`'
 				);

--- a/packages/core/src/config/image-format.ts
+++ b/packages/core/src/config/image-format.ts
@@ -25,6 +25,11 @@ export const validateSelectedPixelFormatAndImageFormatCombination = (
 	pixelFormat: PixelFormat,
 	imageFormat: ImageFormat
 ) => {
+	if (!validOptions.includes(imageFormat)) {
+		throw new TypeError(
+			`Value ${imageFormat} is not valid as an image format.`
+		);
+	}
 	if (pixelFormat !== 'yuva420p') {
 		return;
 	}

--- a/packages/core/src/interpolate.ts
+++ b/packages/core/src/interpolate.ts
@@ -86,9 +86,9 @@ function checkValidInputRange(arr: number[]) {
 		throw new Error('inputRange must have at least 2 elements');
 	}
 	for (let i = 1; i < arr.length; ++i) {
-		if (!(arr[i] >= arr[i - 1])) {
+		if (!(arr[i] > arr[i - 1])) {
 			throw new Error(
-				`inputRange must be monotonically non-decreasing but got [${arr.join(
+				`inputRange must be strictly monotonically non-decreasing but got [${arr.join(
 					','
 				)}]`
 			);

--- a/packages/core/src/test/codec.test.ts
+++ b/packages/core/src/test/codec.test.ts
@@ -1,4 +1,5 @@
 import {
+	CodecOrUndefined,
 	getFinalOutputCodec,
 	getOutputCodecOrUndefined,
 	setCodec,
@@ -8,18 +9,12 @@ import {
 // getFinalOutputCodec
 
 test('Codec tests valid codec input', () => {
-	expect(
-		getFinalOutputCodec({codec: 'h264', emitWarning: true, fileExtension: ''})
-	).toEqual('h264');
-	expect(
-		getFinalOutputCodec({codec: 'h265', emitWarning: true, fileExtension: ''})
-	).toEqual('h265');
-	expect(
-		getFinalOutputCodec({codec: 'vp8', emitWarning: true, fileExtension: ''})
-	).toEqual('vp8');
-	expect(
-		getFinalOutputCodec({codec: 'vp9', emitWarning: true, fileExtension: ''})
-	).toEqual('vp9');
+	const values: CodecOrUndefined[] = ['h264', 'h265', 'vp8', 'vp9'];
+	values.forEach((entry) =>
+		expect(
+			getFinalOutputCodec({codec: entry, emitWarning: true, fileExtension: ''})
+		).toEqual(entry)
+	);
 });
 
 test('Codec tests undefined codec input with known extension', () => {
@@ -69,15 +64,9 @@ test('Codec tests setOutputFormat', () => {
 // setCodec
 
 test('Codec tests setOutputFormat', () => {
-	expect(getOutputCodecOrUndefined()).toEqual(undefined);
-	setCodec('h264');
-	expect(getOutputCodecOrUndefined()).toEqual('h264');
-	setCodec('h265');
-	expect(getOutputCodecOrUndefined()).toEqual('h265');
-	setCodec('vp8');
-	expect(getOutputCodecOrUndefined()).toEqual('vp8');
-	setCodec('vp9');
-	expect(getOutputCodecOrUndefined()).toEqual('vp9');
-	setCodec(undefined);
-	expect(getOutputCodecOrUndefined()).toEqual(undefined);
+	const values: CodecOrUndefined[] = ['h264', 'h265', 'vp8', 'vp9', undefined];
+	values.forEach((entry) => {
+		setCodec(entry);
+		expect(getOutputCodecOrUndefined()).toEqual(entry);
+	});
 });

--- a/packages/core/src/test/codec.test.ts
+++ b/packages/core/src/test/codec.test.ts
@@ -11,7 +11,7 @@ test('Codec tests valid codec input', () => {
 	const values: CodecOrUndefined[] = ['h264', 'h265', 'vp8', 'vp9'];
 	values.forEach((entry) =>
 		expect(
-			getFinalOutputCodec({codec: entry, emitWarning: true, fileExtension: ''})
+			getFinalOutputCodec({codec: entry, emitWarning: false, fileExtension: ''})
 		).toEqual(entry)
 	);
 });
@@ -20,14 +20,14 @@ test('Codec tests undefined codec input with known extension', () => {
 	expect(
 		getFinalOutputCodec({
 			codec: undefined,
-			emitWarning: true,
+			emitWarning: false,
 			fileExtension: 'webm',
 		})
 	).toEqual('vp8');
 	expect(
 		getFinalOutputCodec({
 			codec: undefined,
-			emitWarning: true,
+			emitWarning: false,
 			fileExtension: 'hevc',
 		})
 	).toEqual('h265');

--- a/packages/core/src/test/codec.test.ts
+++ b/packages/core/src/test/codec.test.ts
@@ -1,0 +1,83 @@
+import {
+	getFinalOutputCodec,
+	getOutputCodecOrUndefined,
+	setCodec,
+	setOutputFormat,
+} from '../config/codec';
+
+// getFinalOutputCodec
+
+test('Codec tests valid codec input', () => {
+	expect(
+		getFinalOutputCodec({codec: 'h264', emitWarning: true, fileExtension: ''})
+	).toEqual('h264');
+	expect(
+		getFinalOutputCodec({codec: 'h265', emitWarning: true, fileExtension: ''})
+	).toEqual('h265');
+	expect(
+		getFinalOutputCodec({codec: 'vp8', emitWarning: true, fileExtension: ''})
+	).toEqual('vp8');
+	expect(
+		getFinalOutputCodec({codec: 'vp9', emitWarning: true, fileExtension: ''})
+	).toEqual('vp9');
+});
+
+test('Codec tests undefined codec input with known extension', () => {
+	expect(
+		getFinalOutputCodec({
+			codec: undefined,
+			emitWarning: true,
+			fileExtension: 'webm',
+		})
+	).toEqual('vp8');
+	expect(
+		getFinalOutputCodec({
+			codec: undefined,
+			emitWarning: true,
+			fileExtension: 'hevc',
+		})
+	).toEqual('h265');
+});
+
+test('Codec tests undefined codec input with unknown extension', () => {
+	expect(
+		getFinalOutputCodec({
+			codec: undefined,
+			emitWarning: true,
+			fileExtension: '',
+		})
+	).toEqual('h264');
+	expect(
+		getFinalOutputCodec({
+			codec: undefined,
+			emitWarning: true,
+			fileExtension: 'abc',
+		})
+	).toEqual('h264');
+});
+
+// setOutputFormat
+
+test('Codec tests setOutputFormat', () => {
+	expect(getOutputCodecOrUndefined()).toEqual(undefined);
+	setOutputFormat('mp4');
+	expect(getOutputCodecOrUndefined()).toEqual('h264');
+	setOutputFormat('png-sequence');
+	expect(getOutputCodecOrUndefined()).toEqual(undefined);
+});
+
+// setCodec
+
+test('Codec tests setOutputFormat', () => {
+	expect(getOutputCodecOrUndefined()).toEqual(undefined);
+	setCodec('h264');
+	expect(getOutputCodecOrUndefined()).toEqual('h264');
+	setCodec('h265');
+	expect(getOutputCodecOrUndefined()).toEqual('h265');
+	setCodec('vp8');
+	expect(getOutputCodecOrUndefined()).toEqual('vp8');
+	setCodec('vp9');
+	expect(getOutputCodecOrUndefined()).toEqual('vp9');
+	setCodec(undefined);
+	expect(getOutputCodecOrUndefined()).toEqual(undefined);
+});

--- a/packages/core/src/test/composition-validation.test.tsx
+++ b/packages/core/src/test/composition-validation.test.tsx
@@ -25,8 +25,7 @@ test('It should throw if multiple components have the same id', () => {
 		/The "width/
 	);
 });
-
-test('It should throw if multiple components have the same id', () => {
+test('It should throw if height is a negative number', () => {
 	expectToThrow(
 		() =>
 			render(
@@ -42,5 +41,294 @@ test('It should throw if multiple components have the same id', () => {
 				</RemotionRoot>
 			),
 		/The "height" of a composition must be positive, but got -100./
+	);
+});
+test('It should throw if height=0 is boundary off-point', () => {
+	expectToThrow(
+		() =>
+			render(
+				<RemotionRoot>
+					<Composition
+						lazyComponent={() => Promise.resolve({default: AnyComp})}
+						durationInFrames={100}
+						fps={30}
+						height={0}
+						width={100}
+						id="id"
+					/>
+				</RemotionRoot>
+			),
+		/The "height" of a composition must be positive, but got 0./
+	);
+});
+test('It should not throw if height is a positive number', () => {
+	expect(() =>
+		render(
+			<Composition
+				lazyComponent={() => Promise.resolve({default: AnyComp})}
+				durationInFrames={100}
+				fps={30}
+				height={100}
+				width={100}
+				id="id"
+			/>
+		)
+	).not.toThrow();
+});
+test('It should not throw if height=1 is boundary on-point', () => {
+	expect(() =>
+		render(
+			<Composition
+				lazyComponent={() => Promise.resolve({default: AnyComp})}
+				durationInFrames={100}
+				fps={30}
+				height={1}
+				width={100}
+				id="id"
+			/>
+		)
+	).not.toThrow();
+});
+test('It should throw if height is not a number', () => {
+	expectToThrow(
+		() =>
+			render(
+				<RemotionRoot>
+					<Composition
+						lazyComponent={() => Promise.resolve({default: AnyComp})}
+						durationInFrames={100}
+						fps={30}
+						// @ts-expect-error
+						height={'100'}
+						width={100}
+						id="id"
+					/>
+				</RemotionRoot>
+			),
+		/The "height" of a composition must be a number, but you passed a string/
+	);
+});
+
+test('It should throw if width is a negative number', () => {
+	expectToThrow(
+		() =>
+			render(
+				<RemotionRoot>
+					<Composition
+						lazyComponent={() => Promise.resolve({default: AnyComp})}
+						durationInFrames={100}
+						fps={30}
+						height={100}
+						width={-100}
+						id="id"
+					/>
+				</RemotionRoot>
+			),
+		/The "width" of a composition must be positive, but got -100./
+	);
+});
+test('It should throw if width=0 is boundary off-point', () => {
+	expectToThrow(
+		() =>
+			render(
+				<RemotionRoot>
+					<Composition
+						lazyComponent={() => Promise.resolve({default: AnyComp})}
+						durationInFrames={100}
+						fps={30}
+						height={100}
+						width={0}
+						id="id"
+					/>
+				</RemotionRoot>
+			),
+		/The "width" of a composition must be positive, but got 0./
+	);
+});
+test('It should not throw if width is a positive number', () => {
+	expect(() =>
+		render(
+			<Composition
+				lazyComponent={() => Promise.resolve({default: AnyComp})}
+				durationInFrames={100}
+				fps={30}
+				height={100}
+				width={100}
+				id="id"
+			/>
+		)
+	).not.toThrow();
+});
+test('It should not throw if width=1 is boundary on-point', () => {
+	expect(() =>
+		render(
+			<Composition
+				lazyComponent={() => Promise.resolve({default: AnyComp})}
+				durationInFrames={100}
+				fps={30}
+				height={100}
+				width={1}
+				id="id"
+			/>
+		)
+	).not.toThrow();
+});
+test('It should throw if width is not a number', () => {
+	expectToThrow(
+		() =>
+			render(
+				<RemotionRoot>
+					<Composition
+						lazyComponent={() => Promise.resolve({default: AnyComp})}
+						durationInFrames={100}
+						fps={30}
+						height={100}
+						// @ts-expect-error
+						width={'100'}
+						id="id"
+					/>
+				</RemotionRoot>
+			),
+		/The "width" of a composition must be a number, but you passed a string/
+	);
+});
+
+test('It should throw if durationInFrames of a composition is a negative number', () => {
+	expectToThrow(
+		() =>
+			render(
+				<RemotionRoot>
+					<Composition
+						lazyComponent={() => Promise.resolve({default: AnyComp})}
+						durationInFrames={-100}
+						fps={30}
+						height={100}
+						width={100}
+						id="id"
+					/>
+				</RemotionRoot>
+			),
+		/The "durationInFrames" of a composition must be positive, but got -100./
+	);
+});
+test('It should throw if durationInFrames=0 of a composition is boundary off-point', () => {
+	expectToThrow(
+		() =>
+			render(
+				<RemotionRoot>
+					<Composition
+						lazyComponent={() => Promise.resolve({default: AnyComp})}
+						durationInFrames={0}
+						fps={30}
+						height={100}
+						width={100}
+						id="id"
+					/>
+				</RemotionRoot>
+			),
+		/The "durationInFrames" of a composition must be positive, but got 0./
+	);
+});
+test('It should not throw if durationInFrames=1 of a composition is boundary on-point', () => {
+	expect(() =>
+		render(
+			<Composition
+				lazyComponent={() => Promise.resolve({default: AnyComp})}
+				durationInFrames={1}
+				fps={30}
+				height={100}
+				width={100}
+				id="id"
+			/>
+		)
+	).not.toThrow();
+});
+test('It should throw if durationInFrames of a composition is not a number', () => {
+	expectToThrow(
+		() =>
+			render(
+				<RemotionRoot>
+					<Composition
+						lazyComponent={() => Promise.resolve({default: AnyComp})}
+						// @ts-expect-error
+						durationInFrames={'100'}
+						fps={30}
+						height={100}
+						width={100}
+						id="id"
+					/>
+				</RemotionRoot>
+			),
+		/The "durationInFrames" of a composition must be a number, but you passed a string/
+	);
+});
+
+test('It should throw if fps is of a composition is negative', () => {
+	expectToThrow(
+		() =>
+			render(
+				<RemotionRoot>
+					<Composition
+						lazyComponent={() => Promise.resolve({default: AnyComp})}
+						durationInFrames={100}
+						fps={-30}
+						height={100}
+						width={100}
+						id="id"
+					/>
+				</RemotionRoot>
+			),
+		/The "fps" of a composition must be positive, but got -30./
+	);
+});
+test('It should throw if fps=0 of a composition is boundary off-point', () => {
+	expectToThrow(
+		() =>
+			render(
+				<RemotionRoot>
+					<Composition
+						lazyComponent={() => Promise.resolve({default: AnyComp})}
+						durationInFrames={100}
+						fps={0}
+						height={100}
+						width={100}
+						id="id"
+					/>
+				</RemotionRoot>
+			),
+		/The "fps" of a composition must be positive, but got 0./
+	);
+});
+test('It should not throw if fps=1 of a composition is boundary on-point', () => {
+	expect(() =>
+		render(
+			<Composition
+				lazyComponent={() => Promise.resolve({default: AnyComp})}
+				durationInFrames={100}
+				fps={1}
+				height={100}
+				width={100}
+				id="id"
+			/>
+		)
+	).not.toThrow();
+});
+test('It should throw if fps of a composition is not a number', () => {
+	expectToThrow(
+		() =>
+			render(
+				<RemotionRoot>
+					<Composition
+						lazyComponent={() => Promise.resolve({default: AnyComp})}
+						durationInFrames={100}
+						// @ts-expect-error
+						fps={'30'}
+						height={100}
+						width={100}
+						id="id"
+					/>
+				</RemotionRoot>
+			),
+		/The "fps" of a composition must be a number, but you passed a string/
 	);
 });

--- a/packages/core/src/test/crf.test.ts
+++ b/packages/core/src/test/crf.test.ts
@@ -1,0 +1,132 @@
+import {
+	getActualCrf,
+	getDefaultCrfForCodec,
+	getValidCrfRanges,
+	setCrf,
+	validateSelectedCrfAndCodecCombination,
+} from '../config/crf';
+import {expectToThrow} from './expect-to-throw';
+
+test('crf tests getDefaultCrfForCodec', () => {
+	// input codec, output
+	const valuesA = [
+		['h264', 18],
+		['h265', 23],
+		['vp8', 9],
+		['vp9', 28],
+	];
+	valuesA.forEach((entry) =>
+		// @ts-expect-error
+		expect(getDefaultCrfForCodec(entry[0])).toEqual(entry[1])
+	);
+
+	// input codec
+	const valuesB = ['abc', '', 3, undefined];
+	valuesB.forEach((entry) =>
+		expectToThrow(
+			// @ts-expect-error
+			() => getDefaultCrfForCodec(entry),
+			new RegExp(`Got unexpected codec "${entry}"`)
+		)
+	);
+});
+
+test('crf tests getValidCrfRanges', () => {
+	// input crf, input codec, valid range
+	const valuesA = [
+		['h264', [0, 51]],
+		['h265', [0, 51]],
+		['vp8', [4, 63]],
+		['vp9', [0, 63]],
+	];
+	valuesA.forEach((entry) =>
+		// @ts-expect-error
+		expect(getValidCrfRanges(entry[0])).toEqual(entry[1])
+	);
+
+	// input codec
+	const valuesB = ['abc', '', 3, undefined];
+	valuesB.forEach((entry) =>
+		expectToThrow(
+			// @ts-expect-error
+			() => getValidCrfRanges(entry),
+			new RegExp(`Got unexpected codec "${entry}"`)
+		)
+	);
+});
+
+test('validateSelectedCrfAndCodecCombination', () => {
+	// input crf, input codec
+	const valuesA = [
+		[20, 'h264'],
+		[0, 'h264'],
+		[51, 'h264'],
+		[20, 'h265'],
+		[0, 'h265'],
+		[51, 'h265'],
+		[20, 'vp8'],
+		[4, 'vp8'],
+		[63, 'vp8'],
+		[20, 'vp9'],
+		[0, 'vp9'],
+		[63, 'vp9'],
+	];
+	valuesA.forEach((entry) =>
+		expect(
+			// @ts-expect-error
+			() => validateSelectedCrfAndCodecCombination(entry[0], entry[1])
+		).not.toThrow()
+	);
+
+	// input crf, input codec, valid range
+	const valuesB = [
+		[80, 'h264', [0, 51]],
+		[-1, 'h264', [0, 51]],
+		[52, 'h264', [0, 51]],
+		[80, 'h265', [0, 51]],
+		[-1, 'h265', [0, 51]],
+		[52, 'h265', [0, 51]],
+		[80, 'vp8', [4, 63]],
+		[3, 'vp8', [4, 63]],
+		[64, 'vp8', [4, 63]],
+		[80, 'vp9', [0, 63]],
+		[-1, 'vp9', [0, 63]],
+		[64, 'vp9', [0, 63]],
+	];
+	valuesB.forEach((entry) =>
+		expectToThrow(
+			// @ts-expect-error
+			() => validateSelectedCrfAndCodecCombination(entry[0], entry[1]),
+			new RegExp(
+				// @ts-expect-error
+				`CRF must be between ${entry[2][0]} and ${entry[2][1]} for codec ${entry[1]}. Passed: ${entry[0]}`
+			)
+		)
+	);
+});
+
+test('get crf', () => {
+	// input crf, input codec, output crf
+	const valuesA = [
+		[20, 'h264', 20],
+		[undefined, 'h264', 18],
+		[100, 'h264', 18],
+		[20, 'h265', 20],
+		[undefined, 'h265', 23],
+		[100, 'h265', 23],
+		[20, 'vp8', 20],
+		[undefined, 'vp8', 9],
+		[100, 'vp8', 9],
+		[20, 'vp9', 20],
+		[undefined, 'vp9', 28],
+		[100, 'vp9', 28],
+	];
+	valuesA.forEach((entry) => {
+		// @ts-expect-error
+		setCrf(entry[0]);
+		expect(
+			// @ts-expect-error
+			getActualCrf(entry[1])
+		).toEqual(entry[2]);
+	});
+});

--- a/packages/core/src/test/crf.test.ts
+++ b/packages/core/src/test/crf.test.ts
@@ -1,3 +1,4 @@
+import {Codec} from '../config';
 import {
 	getActualCrf,
 	getDefaultCrfForCodec,
@@ -14,9 +15,8 @@ test('crf tests getDefaultCrfForCodec', () => {
 		['h265', 23],
 		['vp8', 9],
 		['vp9', 28],
-	];
+	] as [Codec, number][];
 	valuesA.forEach((entry) =>
-		// @ts-expect-error
 		expect(getDefaultCrfForCodec(entry[0])).toEqual(entry[1])
 	);
 
@@ -38,9 +38,8 @@ test('crf tests getValidCrfRanges', () => {
 		['h265', [0, 51]],
 		['vp8', [4, 63]],
 		['vp9', [0, 63]],
-	];
+	] as [Codec, [number, number]][];
 	valuesA.forEach((entry) =>
-		// @ts-expect-error
 		expect(getValidCrfRanges(entry[0])).toEqual(entry[1])
 	);
 
@@ -70,11 +69,10 @@ test('validateSelectedCrfAndCodecCombination', () => {
 		[20, 'vp9'],
 		[0, 'vp9'],
 		[63, 'vp9'],
-	];
+	] as [number, Codec][];
 	valuesA.forEach((entry) =>
-		expect(
-			// @ts-expect-error
-			() => validateSelectedCrfAndCodecCombination(entry[0], entry[1])
+		expect(() =>
+			validateSelectedCrfAndCodecCombination(entry[0], entry[1])
 		).not.toThrow()
 	);
 
@@ -92,13 +90,11 @@ test('validateSelectedCrfAndCodecCombination', () => {
 		[80, 'vp9', [0, 63]],
 		[-1, 'vp9', [0, 63]],
 		[64, 'vp9', [0, 63]],
-	];
+	] as [number, Codec, [number, number]][];
 	valuesB.forEach((entry) =>
 		expectToThrow(
-			// @ts-expect-error
 			() => validateSelectedCrfAndCodecCombination(entry[0], entry[1]),
 			new RegExp(
-				// @ts-expect-error
 				`CRF must be between ${entry[2][0]} and ${entry[2][1]} for codec ${entry[1]}. Passed: ${entry[0]}`
 			)
 		)
@@ -116,14 +112,10 @@ test('get crf', () => {
 		[undefined, 'vp8', 9],
 		[20, 'vp9', 20],
 		[undefined, 'vp9', 28],
-	];
+	] as [number | undefined, Codec, number][];
 	valuesA.forEach((entry) => {
-		// @ts-expect-error
 		setCrf(entry[0]);
-		expect(
-			// @ts-expect-error
-			getActualCrf(entry[1])
-		).toEqual(entry[2]);
+		expect(getActualCrf(entry[1])).toEqual(entry[2]);
 	});
 
 	// input crf, input codec, valid range
@@ -132,15 +124,12 @@ test('get crf', () => {
 		[80, 'h265', [0, 51]],
 		[80, 'vp8', [4, 63]],
 		[80, 'vp9', [0, 63]],
-	];
+	] as [number, Codec, [number, number]][];
 	valuesB.forEach((entry) => {
-		// @ts-expect-error
 		setCrf(entry[0]);
 		expectToThrow(
-			// @ts-expect-error
 			() => getActualCrf(entry[1]),
 			new RegExp(
-				// @ts-expect-error
 				`CRF must be between ${entry[2][0]} and ${entry[2][1]} for codec ${entry[1]}. Passed: ${entry[0]}`
 			)
 		);

--- a/packages/core/src/test/crf.test.ts
+++ b/packages/core/src/test/crf.test.ts
@@ -110,16 +110,12 @@ test('get crf', () => {
 	const valuesA = [
 		[20, 'h264', 20],
 		[undefined, 'h264', 18],
-		[100, 'h264', 18],
 		[20, 'h265', 20],
 		[undefined, 'h265', 23],
-		[100, 'h265', 23],
 		[20, 'vp8', 20],
 		[undefined, 'vp8', 9],
-		[100, 'vp8', 9],
 		[20, 'vp9', 20],
 		[undefined, 'vp9', 28],
-		[100, 'vp9', 28],
 	];
 	valuesA.forEach((entry) => {
 		// @ts-expect-error
@@ -128,5 +124,25 @@ test('get crf', () => {
 			// @ts-expect-error
 			getActualCrf(entry[1])
 		).toEqual(entry[2]);
+	});
+
+	// input crf, input codec, valid range
+	const valuesB = [
+		[80, 'h264', [0, 51]],
+		[80, 'h265', [0, 51]],
+		[80, 'vp8', [4, 63]],
+		[80, 'vp9', [0, 63]],
+	];
+	valuesB.forEach((entry) => {
+		// @ts-expect-error
+		setCrf(entry[0]);
+		expectToThrow(
+			// @ts-expect-error
+			() => getActualCrf(entry[1]),
+			new RegExp(
+				// @ts-expect-error
+				`CRF must be between ${entry[2][0]} and ${entry[2][1]} for codec ${entry[1]}. Passed: ${entry[0]}`
+			)
+		);
 	});
 });

--- a/packages/core/src/test/easing.test.ts
+++ b/packages/core/src/test/easing.test.ts
@@ -1,0 +1,52 @@
+import {Easing} from '../easing';
+
+const numbersToTest = [0, 0.2, 0.5, 0.7, 1];
+
+test('Easing linear', () => {
+	const easingIn = Easing.in(Easing.linear);
+	numbersToTest.forEach((n) => expect(easingIn(n)).toBe(n));
+
+	const easingOut = Easing.out(Easing.linear);
+	numbersToTest.forEach((n) => expect(easingOut(n)).toBeCloseTo(n));
+
+	const easingInOut = Easing.inOut(Easing.linear);
+	numbersToTest.forEach((n) => expect(easingInOut(n)).toBe(n));
+});
+
+test('Easing Quadratic', () => {
+	const quad = (n: number) => n * n;
+	const out = (n: number) => 1 - quad(1 - n);
+	const inOut = (n: number) => {
+		if (n >= 0.5) {
+			return 1 - quad((1 - n) * 2) / 2;
+		} else return quad(n * 2) / 2;
+	};
+
+	const easingIn = Easing.in(Easing.quad);
+	numbersToTest.forEach((n) => expect(easingIn(n)).toBe(quad(n)));
+
+	const easingOut = Easing.out(Easing.quad);
+	numbersToTest.forEach((n) => expect(easingOut(n)).toBe(out(n)));
+
+	const easingInOut = Easing.inOut(Easing.quad);
+	numbersToTest.forEach((n) => expect(easingInOut(n)).toBe(inOut(n)));
+});
+
+test('Easing Cubic', () => {
+	const cubic = (n: number) => n * n * n;
+	const out = (n: number) => 1 - cubic(1 - n);
+	const inOut = (n: number) => {
+		if (n >= 0.5) {
+			return 1 - cubic((1 - n) * 2) / 2;
+		} else return cubic(n * 2) / 2;
+	};
+
+	const easingIn = Easing.in(Easing.cubic);
+	numbersToTest.forEach((n) => expect(easingIn(n)).toBe(cubic(n)));
+
+	const easingOut = Easing.out(Easing.cubic);
+	numbersToTest.forEach((n) => expect(easingOut(n)).toBe(out(n)));
+
+	const easingInOut = Easing.inOut(Easing.cubic);
+	numbersToTest.forEach((n) => expect(easingInOut(n)).toBe(inOut(n)));
+});

--- a/packages/core/src/test/image-format.test.ts
+++ b/packages/core/src/test/image-format.test.ts
@@ -1,0 +1,49 @@
+import {
+	setImageFormat,
+	validateSelectedPixelFormatAndImageFormatCombination,
+} from '../config/image-format';
+import {expectToThrow} from './expect-to-throw';
+
+test('It should throw if image format is not valid', () => {
+	expectToThrow(
+		() =>
+			setImageFormat(
+				// @ts-expect-error
+				'invalidImageFormat'
+			),
+		/Value invalidImageFormat is not valid as an image format./
+	);
+});
+test('It should throw if image format is not valid', () => {
+	expectToThrow(
+		() =>
+			validateSelectedPixelFormatAndImageFormatCombination(
+				'yuv420p',
+				// @ts-expect-error
+				'invalidImageFormat'
+			),
+		/Value invalidImageFormat is not valid as an image format./
+	);
+});
+test('It should throw if pixel and image format combination is not valid', () => {
+	expectToThrow(
+		() =>
+			validateSelectedPixelFormatAndImageFormatCombination('yuva420p', 'jpeg'),
+		/Pixel format was set to 'yuva420p' but the image format is not PNG. To render transparent videos, you need to set PNG as the image format./
+	);
+});
+test('It should not throw if pixel and image format combination is valid', () => {
+	expect(() =>
+		validateSelectedPixelFormatAndImageFormatCombination('yuva420p', 'png')
+	).not.toThrow();
+});
+test('It should not throw if pixel and image format combination is valid', () => {
+	expect(() =>
+		validateSelectedPixelFormatAndImageFormatCombination('yuv420p', 'png')
+	).not.toThrow();
+});
+test('It should not throw if pixel and image format combination is valid', () => {
+	expect(() =>
+		validateSelectedPixelFormatAndImageFormatCombination('yuv420p', 'jpeg')
+	).not.toThrow();
+});

--- a/packages/core/src/test/interpolate.test.ts
+++ b/packages/core/src/test/interpolate.test.ts
@@ -7,6 +7,8 @@ test('Basic interpolations', () => {
 	expect(interpolate(Math.PI, [0, 1, 4, 9], [0, 2, 1000, -1000])).toEqual(
 		714.4364894275378
 	);
+	expect(interpolate(Infinity, [0, 1], [0, 2])).toEqual(Infinity);
+	expect(interpolate(Infinity, [0, 1], [1, 0])).toEqual(-Infinity);
 });
 
 test('Must be the same length', () => {
@@ -15,26 +17,33 @@ test('Must be the same length', () => {
 	}, /inputRange \(2\) and outputRange \(3\) must have the same length/);
 });
 
-test('Test against Infinity values', () => {
-	expectToThrow(() => {
-		interpolate(1, [-Infinity, Infinity], [0, 2]);
-	}, /inputRange must contain only finite numbers, but got \[-Infinity,Infinity\]/);
-});
-
-test('Must pass at least 2 elements', () => {
+test('Must pass at least 2 elements for input range', () => {
 	expectToThrow(() => {
 		interpolate(1, [0], [9]);
 	}, /inputRange must have at least 2 elements/);
 });
 
-test('Input range must be monotonically non-decreasing', () => {
+test('Input range must be strictly monotonically non-decreasing', () => {
 	expectToThrow(() => {
 		interpolate(1, [0, 1, 0.5], [0, 2, 0.2]);
-	}, /inputRange must be monotonically non-decreasing/);
+	}, /inputRange must be strictly monotonically non-decreasing/);
+	expectToThrow(() => {
+		interpolate(0.75, [0, 1, 1], [0, 2, 0]);
+	}, /inputRange must be strictly monotonically non-decreasing/);
 });
 
-test('Output range can be monotonically decreasing', () => {
+test('Output range strictly monotonically decreasing', () => {
 	expect(interpolate(0.75, [0, 0.5, 1], [0, 2, 0])).toEqual(1);
+});
+
+test('Output range monotonically decreasing', () => {
+	expect(interpolate(0.75, [0, 0.5, 1], [0, 2, 2])).toEqual(2);
+});
+
+test('Cannot have Infinity in input range', () => {
+	expectToThrow(() => {
+		interpolate(1, [-Infinity, 0], [0, 2]);
+	}, /inputRange must contain only finite numbers, but got \[-Infinity,0\]/);
 });
 
 test('Cannot have Infinity in output Range', () => {
@@ -44,10 +53,24 @@ test('Cannot have Infinity in output Range', () => {
 	);
 });
 
-test('Should throw if passing 2x infinity', () => {
+test('Should throw if passing 2x infinity input range', () => {
 	expectToThrow(
 		() => interpolate(1, [Infinity, Infinity], [0, 2]),
 		/inputRange must contain only finite numbers, but got \[Infinity,Infinity\]/
+	);
+});
+
+test('Should throw if passing 2x infinity output range', () => {
+	expectToThrow(
+		() => interpolate(1, [0, 1], [-Infinity, Infinity]),
+		/outputRange must contain only finite numbers, but got \[-Infinity,Infinity\]/
+	);
+});
+
+test('Should throw on Infinity as third argument', () => {
+	expectToThrow(
+		() => interpolate(1, [0, 1, Infinity], [0, 2, 3]),
+		/inputRange must contain only finite numbers, but got \[0,1,Infinity\]/
 	);
 });
 
@@ -90,6 +113,11 @@ test('Extrapolation identity', () => {
 			extrapolateRight: 'identity',
 		})
 	).toBe(1000);
+	expect(
+		interpolate(-1000, [0, 1, 2], [0, 2, 4], {
+			extrapolateLeft: 'identity',
+		})
+	).toBe(-1000);
 });
 
 test('Clamp right test', () => {
@@ -129,6 +157,10 @@ test('Handle bad types', () => {
 	// @ts-expect-error
 	expect(() => interpolate(1)).toThrowError(
 		/input or inputRange or outputRange can not be undefined/
+	);
+	// @ts-expect-error
+	expect(() => interpolate('1', [0, 1], [1, 0])).toThrowError(
+		/Cannot interpolation an input which is not a number/
 	);
 	// @ts-expect-error
 	expect(() => interpolate(1, 'string', 'string')).toThrowError(

--- a/packages/core/src/test/quality.test.ts
+++ b/packages/core/src/test/quality.test.ts
@@ -1,0 +1,39 @@
+import {getQuality, setQuality} from '../config/quality';
+import {expectToThrow} from './expect-to-throw';
+
+test('set quality tests', () => {
+	// input quality
+	const valuesA = [50, undefined, 100, 1];
+	valuesA.forEach((entry) => {
+		setQuality(entry);
+		expect(getQuality()).toEqual(entry);
+	});
+
+	// input quality, output quality
+	const valuesB = [[0, undefined]];
+	valuesB.forEach((entry) => {
+		setQuality(entry[0]);
+		expect(getQuality()).toEqual(entry[1]);
+	});
+
+	// input quality
+	const valuesC = ['abc', null];
+	valuesC.forEach((entry) =>
+		expectToThrow(
+			// @ts-expect-error
+			() => setQuality(entry),
+			new RegExp(
+				`Quality option must be a number or undefined. Got ${typeof entry}`
+			)
+		)
+	);
+
+	// input quality
+	const valuesD = [-1, 101, 150];
+	valuesD.forEach((entry) =>
+		expectToThrow(
+			() => setQuality(entry),
+			/Quality option must be between 1 and 100./
+		)
+	);
+});

--- a/packages/core/src/test/range.test.tsx
+++ b/packages/core/src/test/range.test.tsx
@@ -1,4 +1,4 @@
-import {setFrameRange} from '../config/frame-range';
+import {setFrameRange, setFrameRangeFromCli} from '../config/frame-range';
 import {Internals} from '../internals';
 import {expectToThrow} from './expect-to-throw';
 
@@ -49,4 +49,30 @@ test('Frame range tests', () => {
 	expect(Internals.getRange()).toEqual(null);
 	setFrameRange([10, 20]);
 	expect(Internals.getRange()).toEqual([10, 20]);
+	setFrameRange(10);
+	expect(Internals.getRange()).toBe(10);
+	setFrameRange(0);
+	expect(Internals.getRange()).toBe(0);
+});
+
+test('Frame range CLI tests', () => {
+	expectToThrow(
+		() => setFrameRangeFromCli('1-2-3'),
+		/--frames flag must be a number or 2 numbers separated by '-', instead got 3 numbers/
+	);
+	expectToThrow(
+		() => setFrameRangeFromCli('2-1'),
+		/The second number of the --frames flag number should be greater or equal than first number/
+	);
+	expectToThrow(
+		() => setFrameRangeFromCli('one-two'),
+		/--frames flag must be a single number, or 2 numbers separated by `-`/
+	);
+	setFrameRange(null);
+	setFrameRangeFromCli(0);
+	expect(Internals.getRange()).toEqual(0);
+	setFrameRangeFromCli(10);
+	expect(Internals.getRange()).toEqual(10);
+	setFrameRangeFromCli('1-10');
+	expect(Internals.getRange()).toEqual([1, 10]);
 });

--- a/packages/core/src/test/sequence-validation.test.tsx
+++ b/packages/core/src/test/sequence-validation.test.tsx
@@ -21,10 +21,12 @@ test('It should allow null as children', () => {
 	).not.toThrow();
 });
 
-test('It should not allow no children at all', () => {
-	expectToThrow(
-		// @ts-expect-error
-		() => render(<Sequence from={0} />),
-		/You passed to durationInFrames an argument of type undefined, but it must be a number./
-	);
+test('It should allow undefined as children', () => {
+	expect(() =>
+		render(
+			<Sequence durationInFrames={100} from={0}>
+				{undefined}
+			</Sequence>
+		)
+	).not.toThrow();
 });


### PR DESCRIPTION
This PR was done together with @calvin-f and @dydent with the goal of improving the quality and coverage of the core package tests.

A few notes on things we changed outside the actual tests:

- The `interpolate()` function was accepting all monotonic non-decreasing input ranges. However, this can lead to ambiguous interpolations e.g. `interpolate(0.75, [0, 1, 1], [0, 2, 0])`. We have therefore narrowed down the conditions for input ranges to only accept strictly monotonic non-decreasing arrays.
- The check if `typeof value !== 'number'` in `frame-range.ts` would always return true since the values were casted to a number before. Changed it to check if the value is `NaN` instead (e.g. if a string is passed)
- Added additional check at the beginning for valid ImageFormat in `image-format.ts`


We ran some coverage stats (just with --coverage flag of jest) and based on them, we improved branch coverage for the core by more than 20%.

So we hope this PR helps, if you have some comments / change requests let us know :)