### PR TITLE
3 second time out for update endpoint

### DIFF
--- a/packages/bundler/src/index.ts
+++ b/packages/bundler/src/index.ts
@@ -8,7 +8,7 @@ import webpack from 'webpack';
 import webpackDevMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
 import {overrideWebpackConfig} from './override-webpack';
-import {isUpdateAvailable} from './update-available';
+import {isUpdateAvailableWithTimeout} from './update-available';
 import {webpackConfig} from './webpack-config';
 
 export const startServer = async (
@@ -45,7 +45,7 @@ export const startServer = async (
 	);
 
 	app.get('/update', (req, res) => {
-		isUpdateAvailable()
+		isUpdateAvailableWithTimeout()
 			.then((data) => {
 				res.json(data);
 			})

--- a/packages/bundler/src/update-available.ts
+++ b/packages/bundler/src/update-available.ts
@@ -5,15 +5,31 @@ export type Info = {
 	currentVersion: string;
 	latestVersion: string;
 	updateAvailable: boolean;
+	timedOut: boolean;
 };
 
-export const isUpdateAvailable = async (): Promise<Info> => {
-	const packageJson = require('../package.json');
+const isUpdateAvailable = async (currentVersion: string): Promise<Info> => {
 	const latest = await latestVersion('@remotion/bundler');
-	const {version} = packageJson;
 	return {
-		updateAvailable: semver.lt(version, latest),
-		currentVersion: version,
+		updateAvailable: semver.lt(currentVersion, latest),
+		currentVersion,
 		latestVersion: latest,
+		timedOut: false,
 	};
+};
+
+export const isUpdateAvailableWithTimeout = () => {
+	const packageJson = require('../package.json');
+	const {version} = packageJson;
+	const threeSecTimeout = new Promise<Info>((resolve) => {
+		setTimeout(() => {
+			resolve({
+				currentVersion: version,
+				latestVersion: version,
+				updateAvailable: false,
+				timedOut: true,
+			});
+		}, 3000);
+	});
+	return Promise.race([threeSecTimeout, isUpdateAvailable(version)]);
 };


### PR DESCRIPTION
Problem: When having a slow internet connection, asset loading is blocked by chrome because the /update endpoint is hanging (request to the internet). Therefore introducting a change that will timeout the request after 3 seconds, update check is non critical.