### PR TITLE
remove unncessary test

### DIFF
--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -46,14 +46,7 @@ export const render = async () => {
 	}
 	const shouldOutputImageSequence = Internals.getShouldOutputImageSequence();
 	const userCodec = Internals.getOutputCodecOrUndefined();
-	if (shouldOutputImageSequence && userCodec) {
-		Log.Error('Detected both --codec and --sequence (formerly --png) flag.');
-		Log.Error(
-			'This is an error - no video codec can be used for image sequences.'
-		);
-		Log.Error('Remove one of the two flags and try again.');
-		process.exit(1);
-	}
+
 	const codec = getFinalOutputCodec({
 		codec: userCodec,
 		fileExtension: getUserPassedFileExtension(),

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -39,28 +39,6 @@ test("Should be able to render video", async () => {
   expect(data).toContain("30 fps");
 });
 
-test("Should fail to render conflicting --sequence and --codec settings", async () => {
-  const task = await execa(
-    "npx",
-    [
-      "remotion",
-      "render",
-      "src/index.tsx",
-      "ten-frame-tester",
-      "--codec",
-      "h264",
-      "--sequence",
-      outputPath,
-    ],
-    {
-      cwd: "packages/example",
-      reject: false,
-    }
-  );
-  expect(task.exitCode).toBe(process.platform === "win32" ? 0 : 1);
-  expect(task.stderr).toContain("Detected both --codec");
-});
-
 test("Should fail to render out of range CRF", async () => {
   const task = await execa(
     "npx",


### PR DESCRIPTION
Think this one doesn't make sense anymore.

You call with `--frames=1` but it fails because in your config you set the codec. Confusing we can still execute the user command without problems. Think it makes sense to loosen it a bit.

Fixes #238 