### PR TITLE
disable loop prop from audio and video / warn about FFPMPEG issues

### DIFF
--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -4,6 +4,7 @@ import {
 	ffmpegHasFeature,
 	getActualConcurrency,
 	getCompositions,
+	getFfmpegVersion,
 	renderFrames,
 	stitchFramesToVideo,
 	validateFfmpeg,
@@ -23,6 +24,7 @@ import {loadConfigFile} from './load-config';
 import {Log} from './log';
 import {parseCommandLine, parsedCli} from './parse-command-line';
 import {getUserPassedFileExtension} from './user-passed-output-location';
+import {warnAboutFfmpegVersion} from './warn-about-ffmpeg-version';
 
 export const render = async () => {
 	const file = parsedCli._[1];
@@ -59,6 +61,9 @@ export const render = async () => {
 		fileExtension: getUserPassedFileExtension(),
 		emitWarning: true,
 	});
+	const ffmpegVersion = await getFfmpegVersion();
+	Log.Verbose('Your FFMPEG version: ', ffmpegVersion);
+	warnAboutFfmpegVersion(ffmpegVersion);
 	if (codec === 'vp8' && !(await ffmpegHasFeature('enable-libvpx'))) {
 		Log.Error(
 			"The Vp8 codec has been selected, but your FFMPEG binary wasn't compiled with the --enable-lipvpx flag."

--- a/packages/cli/src/render.tsx
+++ b/packages/cli/src/render.tsx
@@ -62,7 +62,10 @@ export const render = async () => {
 		emitWarning: true,
 	});
 	const ffmpegVersion = await getFfmpegVersion();
-	Log.Verbose('Your FFMPEG version: ', ffmpegVersion);
+	Log.Verbose(
+		'Your FFMPEG version:',
+		ffmpegVersion ? ffmpegVersion.join('.') : 'Built from source'
+	);
 	warnAboutFfmpegVersion(ffmpegVersion);
 	if (codec === 'vp8' && !(await ffmpegHasFeature('enable-libvpx'))) {
 		Log.Error(

--- a/packages/cli/src/warn-about-ffmpeg-version.ts
+++ b/packages/cli/src/warn-about-ffmpeg-version.ts
@@ -1,0 +1,28 @@
+import {FfmpegVersion} from '@remotion/renderer';
+import {Log} from './log';
+
+export const printMessage = (ffmpegVersion: NonNullable<FfmpegVersion>) => {
+	Log.Warn('Old FFMPEG version detected: ' + ffmpegVersion.join('.'));
+	Log.Warn('For audio support, you need at least version 4.1.0.');
+	Log.Warn('Upgrade FFMPEG to get rid of this warning.');
+};
+
+export const warnAboutFfmpegVersion = (ffmpegVersion: FfmpegVersion) => {
+	if (ffmpegVersion === null) {
+		return null;
+	}
+	const [major, minor] = ffmpegVersion;
+	// 3.x and below definitely is too old
+	if (major < 4) {
+		printMessage(ffmpegVersion);
+		return;
+	}
+	// 5.x will be all good
+	if (major > 4) {
+		return;
+	}
+	if (minor < 1) {
+		printMessage(ffmpegVersion);
+		return;
+	}
+};

--- a/packages/core/src/audio/props.ts
+++ b/packages/core/src/audio/props.ts
@@ -10,7 +10,7 @@ export type RemotionAudioProps = Omit<
 		React.AudioHTMLAttributes<HTMLAudioElement>,
 		HTMLAudioElement
 	>,
-	'autoplay' | 'controls'
+	'autoplay' | 'controls' | 'loop'
 > & {
 	volume?: VolumeProp;
 };

--- a/packages/core/src/video/props.ts
+++ b/packages/core/src/video/props.ts
@@ -10,7 +10,7 @@ export type RemotionVideoProps = Omit<
 		React.VideoHTMLAttributes<HTMLVideoElement>,
 		HTMLVideoElement
 	>,
-	'autoplay' | 'controls'
+	'autoplay' | 'controls' | 'loop'
 > & {
 	volume?: VolumeProp;
 };

--- a/packages/renderer/src/ffmpeg-flags.ts
+++ b/packages/renderer/src/ffmpeg-flags.ts
@@ -21,3 +21,13 @@ export const ffmpegHasFeature = async (
 	const config = await getFfmpegBuildInfo();
 	return config.includes(feature);
 };
+
+export const parseFfmpegVersion = (
+	buildconf: string
+): [number, number, number] | null => {
+	const match = buildconf.match(/ffmpeg version ([0-9]+).([0-9]+).([0-9]+)/);
+	if (!match) {
+		return null;
+	}
+	return [Number(match[1]), Number(match[2]), Number(match[3])];
+};

--- a/packages/renderer/src/ffmpeg-flags.ts
+++ b/packages/renderer/src/ffmpeg-flags.ts
@@ -3,6 +3,8 @@ import {binaryExists} from './validate-ffmpeg';
 
 let buildConfig: string | null = null;
 
+export type FfmpegVersion = [number, number, number] | null;
+
 const getFfmpegBuildInfo = async () => {
 	if (buildConfig !== null) {
 		return buildConfig;
@@ -22,12 +24,15 @@ export const ffmpegHasFeature = async (
 	return config.includes(feature);
 };
 
-export const parseFfmpegVersion = (
-	buildconf: string
-): [number, number, number] | null => {
+export const parseFfmpegVersion = (buildconf: string): FfmpegVersion => {
 	const match = buildconf.match(/ffmpeg version ([0-9]+).([0-9]+).([0-9]+)/);
 	if (!match) {
 		return null;
 	}
 	return [Number(match[1]), Number(match[2]), Number(match[3])];
+};
+
+export const getFfmpegVersion = async (): Promise<FfmpegVersion> => {
+	const buildInfo = await getFfmpegBuildInfo();
+	return parseFfmpegVersion(buildInfo);
 };

--- a/packages/renderer/src/test/parse-ffmpeg-version.test.ts
+++ b/packages/renderer/src/test/parse-ffmpeg-version.test.ts
@@ -1,0 +1,22 @@
+import {parseFfmpegVersion} from '../ffmpeg-flags';
+
+test('Should parse a normal FFFMPEG version', () => {
+	const buildconf = `
+  ffmpeg version 4.3.1 Copyright (c) 2000-2020 the FFmpeg developers
+    built with Apple clang version 12.0.0 (clang-1200.0.32.28)
+    configuration: --prefix=/usr/local/Cellar/ffmpeg/4.3.1_9 --enable-shared --enable-pthreads --enable-version3 --enable-avresample --cc=clang --host-cflags= --host-ldflags= --enable-ffplay --enable-gnutls --enable-gpl --enable-libaom --enable-libbluray --enable-libdav1d --enable-libmp3lame --enable-libopus --enable-librav1e --enable-librubberband --enable-libsnappy --enable-libsrt --enable-libtesseract --enable-libtheora --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxml2 --enable-libxvid --enable-lzma --enable-libfontconfig --enable-libfreetype --enable-frei0r --enable-libass --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenjpeg --enable-librtmp --enable-libspeex --enable-libsoxr --enable-videotoolbox --enable-libzmq --enable-libzimg --disable-libjack --disable-indev=jack
+  `;
+	expect(parseFfmpegVersion(buildconf)).toEqual([4, 3, 1]);
+});
+
+test('Should return null if running a git version', () => {
+	const buildconf = `
+    ffmpeg -version 
+    ffmpeg version git-2020-08-31-4a11a6f Copyright (c) 2000-2020 the FFmpeg developers
+    built with gcc 10.2.1 (GCC) 20200805
+    configuration: --enable-gpl --enable-version3 --enable-sdl2 --enable-fontconfig --enable-gnutls --enable-iconv --enable-libass --enable-libdav1d --enable-libbluray --enable-libfreetype --enable-libmp3lame --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenjpeg --enable-libopus --enable-libshine --enable-libsnappy --enable-libsoxr 
+    --enable-libsrt --enable-libtheora --enable-libtwolame --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxml2 --enable-libzimg --enable-lzma --enable-zlib --enable-gmp --enable-libvidstab --enable-libvmaf --enable-libvorbis --enable-libvo-amrwbenc --enable-libmysofa --enable-libspeex --enable-libxvid 
+    --enable-libaom --enable-libgsm --enable-librav1e --enable-libsvtav1 --disable-w32threads --enable-libmfx --enable-ffnvcodec --enable-cuda-llvm --enable-cuvid --enable-d3d11va --enable-nvenc --enable-nvdec --enable-dxva2 --enable-avisynth --enable-libopenmpt --enable-amf
+  `;
+	expect(parseFfmpegVersion(buildconf)).toEqual(null);
+});


### PR DESCRIPTION
It makes the user think one can use the loop the video, but this feature is not yet implemented.
Disabling it for now to avoid any confusion.

Fixes #253 

--- 

sorry about these double PRs, I am using the github VSCode extension wrong...

Also fixes #244!