### PR TITLE
fix audio bug

### DIFF
--- a/packages/renderer/src/stringify-ffmpeg-filter.ts
+++ b/packages/renderer/src/stringify-ffmpeg-filter.ts
@@ -33,7 +33,13 @@ export const stringifyFfmpegFilter = ({
 		`[${streamIndex}:a]` +
 		[
 			`atrim=${trimLeft}:${trimRight}`,
-			`adelay=${new Array(channels).fill(startInVideoSeconds).join('|')}`,
+			// For n channels, we delay n + 1 channels.
+			// This is because `ffprobe` for some audio files reports the wrong amount
+			// of channels.
+			// This should be fine because FFMPEG documentation states:
+			// "Unused delays will be silently ignored."
+			// https://ffmpeg.org/ffmpeg-filters.html#adelay
+			`adelay=${new Array(channels + 1).fill(startInVideoSeconds).join('|')}`,
 			`volume=${volumeFilter.value}:eval=${volumeFilter.eval}`,
 		]
 			.filter(Internals.truthy)

--- a/packages/renderer/src/test/ffmpeg-filters.test.ts
+++ b/packages/renderer/src/test/ffmpeg-filters.test.ts
@@ -28,7 +28,7 @@ test('Should create a basic filter correctly', () => {
 			assetAudioDetails,
 			videoTrackCount: 1,
 		})[0].filter
-	).toBe('[1:a]atrim=0.000:0.667,adelay=0,volume=1:eval=once[a1]');
+	).toBe('[1:a]atrim=0.000:0.667,adelay=0|0,volume=1:eval=once[a1]');
 });
 
 test('Should handle trim correctly', () => {
@@ -48,7 +48,7 @@ test('Should handle trim correctly', () => {
 			assetAudioDetails,
 			videoTrackCount: 1,
 		})[0].filter
-	).toBe('[1:a]atrim=0.333:1.000,adelay=0,volume=1:eval=once[a1]');
+	).toBe('[1:a]atrim=0.333:1.000,adelay=0|0,volume=1:eval=once[a1]');
 });
 
 test('Should handle delay correctly', () => {
@@ -69,7 +69,7 @@ test('Should handle delay correctly', () => {
 			assetAudioDetails,
 			videoTrackCount: 1,
 		})[0].filter
-	).toBe('[1:a]atrim=0.333:1.000,adelay=2667,volume=1:eval=once[a1]');
+	).toBe('[1:a]atrim=0.333:1.000,adelay=2667|2667,volume=1:eval=once[a1]');
 });
 
 test('Should offset multiple channels', () => {
@@ -90,5 +90,7 @@ test('Should offset multiple channels', () => {
 			assetAudioDetails,
 			videoTrackCount: 1,
 		})[0].filter
-	).toBe('[1:a]atrim=0.333:1.000,adelay=2667|2667|2667,volume=1:eval=once[a1]');
+	).toBe(
+		'[1:a]atrim=0.333:1.000,adelay=2667|2667|2667|2667,volume=1:eval=once[a1]'
+	);
 });


### PR DESCRIPTION
I've been sent a .wav file for which FFProbe reports that it has 1 channel, but then it is treated as having 2 channels during render. Fixing this by hacking it and always adding one more channel than necessary. It should be harmless though as explained in the comment.
