### PR TITLE
fix audio regression

### DIFF
--- a/packages/renderer/src/calculate-ffmpeg-filters.ts
+++ b/packages/renderer/src/calculate-ffmpeg-filters.ts
@@ -36,7 +36,7 @@ export const calculateFfmpegFilters = ({
 			asset
 		);
 
-		const streamIndex = i + videoTrackCount;
+		const streamIndex = assetPositions.indexOf(asset) + videoTrackCount;
 		return {
 			filter: stringifyFfmpegFilter({
 				streamIndex,

--- a/packages/renderer/src/calculate-ffmpeg-filters.ts
+++ b/packages/renderer/src/calculate-ffmpeg-filters.ts
@@ -25,7 +25,7 @@ export const calculateFfmpegFilters = ({
 				.channels > 0
 		);
 	});
-	return withMoreThan1Channel.map((asset, i) => {
+	return withMoreThan1Channel.map((asset) => {
 		const assetTrimLeft = (asset.trimLeft / fps).toFixed(3);
 		const assetTrimRight = ((asset.trimLeft + asset.duration) / fps).toFixed(3);
 		const audioDetails = assetAudioDetails.get(

--- a/packages/renderer/src/test/ffmpeg-filters.test.ts
+++ b/packages/renderer/src/test/ffmpeg-filters.test.ts
@@ -94,3 +94,52 @@ test('Should offset multiple channels', () => {
 		'[1:a]atrim=0.333:1.000,adelay=2667|2667|2667|2667,volume=1:eval=once[a1]'
 	);
 });
+
+test('Should calculate correct indices even if some muted channels are removed before', () => {
+	const assetAudioDetails = new Map<string, AssetAudioDetails>();
+	const mutedSrc = 'music.mp3';
+	assetAudioDetails.set(mutedSrc, {
+		channels: 0,
+	});
+	assetAudioDetails.set(src, {
+		channels: 3,
+	});
+	const makeFilters = () =>
+		calculateFfmpegFilters({
+			fps: 30,
+			assetPositions: [
+				{
+					trimLeft: 10,
+					startInVideo: 80,
+					duration: 100,
+					id: 'any',
+					isRemote: false,
+					src: mutedSrc,
+					type: 'video',
+					volume: 1,
+				},
+				{
+					...asset,
+					trimLeft: 10,
+					startInVideo: 80,
+				},
+			],
+			assetAudioDetails,
+			videoTrackCount: 1,
+		});
+	expect(makeFilters()[0].filter).toBe(
+		// Should be index 2 - make sure that index 1 is not current, because it is muted
+		'[2:a]atrim=0.333:1.000,adelay=2667|2667|2667|2667,volume=1:eval=once[a2]'
+	);
+
+	// Also test basic case: if first one is unmuted, both channels are there again
+	assetAudioDetails.set(mutedSrc, {
+		channels: 1,
+	});
+	expect(makeFilters()[0].filter).toBe(
+		'[1:a]atrim=0.333:3.667,adelay=2667|2667,volume=2:eval=once[a1]'
+	);
+	expect(makeFilters()[1].filter).toBe(
+		'[2:a]atrim=0.333:1.000,adelay=2667|2667|2667|2667,volume=2:eval=once[a2]'
+	);
+});


### PR DESCRIPTION
I broke this 3 days ago.

If an asset has no audio and is followed by assets that have audio, then the filters get shifted. Fixing it with this PR