### PR TITLE
use yarn or npm given `yarn create` or `npm init`

### DIFF
--- a/packages/create-video/package.json
+++ b/packages/create-video/package.json
@@ -12,6 +12,8 @@
 	],
 	"scripts": {
 		"build": "tsc -d"
+		"build": "tsc -d",
+		"watch": "tsc -w"
 	},
 	"author": "",
 	"license": "SEE LICENSE IN LICENSE.md",

--- a/packages/create-video/package.json
+++ b/packages/create-video/package.json
@@ -11,7 +11,6 @@
 		"_template"
 	],
 	"scripts": {
-		"build": "tsc -d"
 		"build": "tsc -d",
 		"watch": "tsc -w"
 	},

--- a/packages/create-video/src/init.ts
+++ b/packages/create-video/src/init.ts
@@ -19,9 +19,17 @@ const askQuestion = (question: string) => {
 	});
 };
 
+const shouldUseYarn = (binaryPath: string): boolean => {
+	if (binaryPath.match(/.yarn/g)) {
+		return true;
+	}
+	return false;
+};
+
 xns(async () => {
 	const arg = process.argv[2];
 	let selectedDirname = arg?.match(/[a-zA-Z0-9-]+/g) ? arg : '';
+	const createVideoBinaryPath = process.argv[1];
 	while (selectedDirname === '') {
 		const answer =
 			(await askQuestion(
@@ -61,13 +69,23 @@ xns(async () => {
 		)}. Installing dependencies...`
 	);
 	console.log('');
-	console.log('> npm install');
-	const promise = execa('npm', ['install'], {
-		cwd: outputDir,
-	});
-	promise.stderr?.pipe(process.stderr);
-	promise.stdout?.pipe(process.stdout);
-	await promise;
+	if (shouldUseYarn(createVideoBinaryPath)) {
+		console.log('> yarn');
+		const promise = execa('yarn', [''], {
+			cwd: outputDir,
+		});
+		promise.stderr?.pipe(process.stderr);
+		promise.stdout?.pipe(process.stdout);
+		await promise;
+	} else {
+		console.log('> npm install');
+		const promise = execa('npm', ['install'], {
+			cwd: outputDir,
+		});
+		promise.stderr?.pipe(process.stderr);
+		promise.stdout?.pipe(process.stdout);
+		await promise;
+	}
 
 	console.log(`Welcome to ${chalk.blue('Remotion')}!`);
 	console.log(
@@ -76,10 +94,18 @@ xns(async () => {
 
 	console.log('Get started by running');
 	console.log(chalk.blue(`cd ${selectedDirname}`));
-	console.log(chalk.blue('npm start'));
+	console.log(
+		chalk.blue(
+			shouldUseYarn(createVideoBinaryPath) ? 'yarn start' : 'npm start'
+		)
+	);
 	console.log('');
 	console.log('To render an MP4 video, run');
-	console.log(chalk.blue('npm run build'));
+	console.log(
+		chalk.blue(
+			shouldUseYarn(createVideoBinaryPath) ? 'yarn build' : 'npm run build'
+		)
+	);
 	console.log('');
 	console.log(
 		'Read the documentation at',

--- a/packages/create-video/src/init.ts
+++ b/packages/create-video/src/init.ts
@@ -19,14 +19,16 @@ const askQuestion = (question: string) => {
 	});
 };
 
-const shouldUseYarn = (binaryPath: string): boolean => {
-	return Boolean(binaryPath.match(/.yarn/g));
+const shouldUseYarn = (): boolean => {
+	return Boolean(
+		process.env.npm_execpath?.includes('yarn.js') ||
+			process.env.npm_config_user_agent?.includes('yarn')
+	);
 };
 
 xns(async () => {
 	const arg = process.argv[2];
 	let selectedDirname = arg?.match(/[a-zA-Z0-9-]+/g) ? arg : '';
-	const createVideoBinaryPath = process.argv[1];
 	while (selectedDirname === '') {
 		const answer =
 			(await askQuestion(
@@ -66,7 +68,7 @@ xns(async () => {
 		)}. Installing dependencies...`
 	);
 	console.log('');
-	if (shouldUseYarn(createVideoBinaryPath)) {
+	if (shouldUseYarn()) {
 		console.log('> yarn');
 		const promise = execa('yarn', [], {
 			cwd: outputDir,
@@ -91,18 +93,10 @@ xns(async () => {
 
 	console.log('Get started by running');
 	console.log(chalk.blue(`cd ${selectedDirname}`));
-	console.log(
-		chalk.blue(
-			shouldUseYarn(createVideoBinaryPath) ? 'yarn start' : 'npm start'
-		)
-	);
+	console.log(chalk.blue(shouldUseYarn() ? 'yarn start' : 'npm start'));
 	console.log('');
 	console.log('To render an MP4 video, run');
-	console.log(
-		chalk.blue(
-			shouldUseYarn(createVideoBinaryPath) ? 'yarn build' : 'npm run build'
-		)
-	);
+	console.log(chalk.blue(shouldUseYarn() ? 'yarn build' : 'npm run build'));
 	console.log('');
 	console.log(
 		'Read the documentation at',

--- a/packages/create-video/src/init.ts
+++ b/packages/create-video/src/init.ts
@@ -20,10 +20,7 @@ const askQuestion = (question: string) => {
 };
 
 const shouldUseYarn = (binaryPath: string): boolean => {
-	if (binaryPath.match(/.yarn/g)) {
-		return true;
-	}
-	return false;
+	return Boolean(binaryPath.match(/.yarn/g));
 };
 
 xns(async () => {
@@ -70,8 +67,8 @@ xns(async () => {
 	);
 	console.log('');
 	if (shouldUseYarn(createVideoBinaryPath)) {
-		console.log('> yarn install');
-		const promise = execa('yarn', ['install'], {
+		console.log('> yarn');
+		const promise = execa('yarn', [], {
 			cwd: outputDir,
 		});
 		promise.stderr?.pipe(process.stderr);

--- a/packages/create-video/src/init.ts
+++ b/packages/create-video/src/init.ts
@@ -70,8 +70,8 @@ xns(async () => {
 	);
 	console.log('');
 	if (shouldUseYarn(createVideoBinaryPath)) {
-		console.log('> yarn');
-		const promise = execa('yarn', [''], {
+		console.log('> yarn install');
+		const promise = execa('yarn', ['install'], {
 			cwd: outputDir,
 		});
 		promise.stderr?.pipe(process.stderr);


### PR DESCRIPTION
fixes #276 
now `create-video` understands that you are using `npm` or `yarn` as a package manager, default's to `npm` as a package manager.
