### PR TITLE
Interpolation improvements

### DIFF
--- a/packages/core/src/interpolate.ts
+++ b/packages/core/src/interpolate.ts
@@ -46,34 +46,14 @@ function interpolateFunction(
 		return outputMin;
 	}
 
-	if (inputMin === inputMax) {
-		if (input <= inputMin) {
-			return outputMin;
-		}
-
-		return outputMax;
-	}
-
 	// Input Range
-	if (inputMin === -Infinity) {
-		result = -result;
-	} else if (inputMax === Infinity) {
-		result -= inputMin;
-	} else {
-		result = (result - inputMin) / (inputMax - inputMin);
-	}
+	result = (result - inputMin) / (inputMax - inputMin);
 
 	// Easing
 	result = easing(result);
 
 	// Output Range
-	if (outputMin === -Infinity) {
-		result = -result;
-	} else if (outputMax === Infinity) {
-		result += outputMin;
-	} else {
-		result = result * (outputMax - outputMin) + outputMin;
-	}
+	result = result * (outputMax - outputMin) + outputMin;
 
 	return result;
 }
@@ -90,10 +70,6 @@ function findRange(input: number, inputRange: readonly number[]) {
 }
 
 function checkValidInputRange(arr: readonly number[]) {
-	if (arr.length < 2) {
-		throw new Error('inputRange must have at least 2 elements');
-	}
-
 	for (let i = 1; i < arr.length; ++i) {
 		if (!(arr[i] > arr[i - 1])) {
 			throw new Error(
@@ -108,12 +84,6 @@ function checkValidInputRange(arr: readonly number[]) {
 function checkInfiniteRange(name: string, arr: readonly number[]) {
 	if (arr.length < 2) {
 		throw new Error(name + ' must have at least 2 elements');
-	}
-
-	if (!(arr.length !== 2 || arr[0] !== -Infinity || arr[1] !== Infinity)) {
-		throw new Error(
-			`${name} must contain only finite numbers, but got [${arr.join(',')}]`
-		);
 	}
 
 	for (const index in arr) {
@@ -158,9 +128,9 @@ export function interpolate(
 	}
 
 	checkInfiniteRange('inputRange', inputRange);
-	checkValidInputRange(inputRange);
-
 	checkInfiniteRange('outputRange', outputRange);
+
+	checkValidInputRange(inputRange);
 
 	const easing = options?.easing ?? ((num: number): number => num);
 

--- a/packages/core/src/test/interpolate.test.ts
+++ b/packages/core/src/test/interpolate.test.ts
@@ -2,13 +2,24 @@ import {Easing} from '../easing';
 import {interpolate} from '../interpolate';
 import {expectToThrow} from './expect-to-throw';
 
-test('Basic interpolations', () => {
-	expect(interpolate(1, [0, 1], [0, 2])).toEqual(2);
-	expect(interpolate(Math.PI, [0, 1, 4, 9], [0, 2, 1000, -1000])).toEqual(
-		714.4364894275378
-	);
-	expect(interpolate(Infinity, [0, 1], [0, 2])).toEqual(Infinity);
-	expect(interpolate(Infinity, [0, 1], [1, 0])).toEqual(-Infinity);
+describe('Basic interpolations', () => {
+	test('Input and output range strictly monotonically increasing', () => {
+		expect(interpolate(1, [0, 1], [0, 2])).toEqual(2);
+	});
+	test('Input range strictly monotonically increasing, Output range non-increasing', () => {
+		expect(interpolate(1, [0, 1], [2, 2])).toEqual(2);
+	});
+	test('Interpolate with 4 values, output non-increasing', () => {
+		expect(interpolate(Math.PI, [0, 1, 4, 9], [0, 2, 1000, -1000])).toEqual(
+			714.4364894275378
+		);
+	});
+	test('Interpolate Infinity: output range increasing', () => {
+		expect(interpolate(Infinity, [0, 1], [0, 2])).toEqual(Infinity);
+	});
+	test('Interpolate Infinity: output range decreasing', () => {
+		expect(interpolate(Infinity, [0, 1], [1, 0])).toEqual(-Infinity);
+	});
 });
 
 test('Must be the same length', () => {
@@ -162,7 +173,15 @@ test('Zig-zag test', () => {
 
 test('Handle bad types', () => {
 	// @ts-expect-error
-	expect(() => interpolate()).toThrowError(
+	expect(() => interpolate(undefined, [0, 1], [1, 0])).toThrowError(
+		/input or inputRange or outputRange can not be undefined/
+	);
+	// @ts-expect-error
+	expect(() => interpolate(1, undefined, [1, 0])).toThrowError(
+		/input or inputRange or outputRange can not be undefined/
+	);
+	// @ts-expect-error
+	expect(() => interpolate(1, [1, 0], undefined)).toThrowError(
 		/input or inputRange or outputRange can not be undefined/
 	);
 	// @ts-expect-error


### PR DESCRIPTION
I did some mutation testing using Stryker and i stumbled over quite a few branches in the interpolation file which are never reached (and therefore can be arbitrarily mutated with all tests still passing).

- `inputMin === inputMax` doesn't need to be tested, because we require input ranges to be **strictly** monotonically increasing
- Removed all checks for Inifinity in input/output ranges as we only allow finite numbers.
- removed array length check in `checkValidInputRange` as it is already done in `checkInfiniteRange `
- removed `if (!(arr.length !== 2 || arr[0] !== -Infinity || arr[1] !== Infinity))` which is logically equivalent to `if(arr.length === 2 && arr[0] === -Infinity & arr[1] === Infinity)` => This very specific case is already covered by the following loop and I don't see the need for an extra check before.

I also improved the tests a tiny bit and everything is still passing. Hope it helps :) 
