### PR TITLE
Fix typo in CLI docs

### DIFF
--- a/packages/docs/docs/cli.md
+++ b/packages/docs/docs/cli.md
@@ -31,7 +31,7 @@ Inline JSON string isn't supported on Windows because it removes the `"` charact
 
 ### `--image-format`
 
-[`jpeg` or `png` - JPEG is faster, but supports transparency.](/docs/config#setimageformat) The default image format is `jpeg` since v1.1. Flag available since v1.4.
+[`jpeg` or `png` - JPEG is faster, but doesn't support transparency.](/docs/config#setimageformat) The default image format is `jpeg` since v1.1. Flag available since v1.4.
 
 ### `--config`
 


### PR DESCRIPTION
<!---
  Please make sure to read CONTRIBUTING.md before sending a pull request.
  Thank you!
-->

Changed a phrase in docs/cli since it wasn't clear. 
Another alternative could be:
```
JPEG is faster, but PNG supports transparency. 
```

Thank you for remotion <3 