### PR TITLE
prevent really long sequence names taking up all space in the timeline

### DIFF
--- a/packages/cli/src/editor/components/Timeline/TimelineListItem.tsx
+++ b/packages/cli/src/editor/components/Timeline/TimelineListItem.tsx
@@ -21,6 +21,7 @@ const outer: React.CSSProperties = {
 	alignItems: 'center',
 	fontSize: 13,
 	paddingLeft: TIMELINE_PADDING,
+	wordBreak: 'break-all',
 };
 
 const hookContainer: React.CSSProperties = {
@@ -105,6 +106,10 @@ export const TimelineListItem: React.FC<{
 			});
 		}
 	}, [collapsed, dispatchStateChange, hash]);
+	const text =
+		sequence.displayName.length > 80
+			? sequence.displayName.slice(0, 80) + '...'
+			: sequence.displayName;
 
 	return (
 		<div style={outer}>
@@ -125,7 +130,7 @@ export const TimelineListItem: React.FC<{
 					<div style={space} />
 				</>
 			) : null}
-			{sequence.displayName}
+			{text}
 		</div>
 	);
 };


### PR DESCRIPTION
```
<Sequence
			name="reallylongfsdhkjfasdkjfhsadlkfjhsdakjlfhsadjlkfhasdlkfjhasdlkfhaskljfhasdlfjkhsadlfjkadshfljkashdflkdhfsfsdfsdfsdfsdfdsfsdffdsfdsfsdfsddsfgsdfgdfsgfdsgdsfgdfsfsdfdsfsdfasfsafgasdfsafasdfdsfdsfsdfasfsdafasdfsadfsadfasdfasdfsafsdafsdafasdfsdf"
			from={0}
			durationInFrames={Infinity}
		>
```

would break the layout previously and make the timeline unusable. Fixing it with this PR.