### PR TITLE
fix rendering on very long videos

### DIFF
--- a/packages/renderer/src/get-frame-number-length.ts
+++ b/packages/renderer/src/get-frame-number-length.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import {max, min} from './min-max';
+
+// If the biggest frame has the number 100 (3 digits), we need to tell FFMPEG
+// that it has to expect up to three digits, etc. We calculate the length of
+// the biggest number.
+export const getFrameInfo = async ({
+	dir,
+	isAudioOnly,
+}: {
+	dir: string;
+	isAudioOnly: boolean;
+}): Promise<null | {
+	numberLength: number;
+	startNumber: number;
+}> => {
+	if (isAudioOnly) {
+		return null;
+	}
+
+	const files = await fs.promises.readdir(dir);
+	const numbers = files
+		.filter((f) => f.match(/element-([0-9]+)/))
+		.map((f) => {
+			return f.match(/element-([0-9]+)/)?.[1] as string;
+		})
+		.map((f) => Number(f));
+	const biggestNumber = max(numbers);
+	const smallestNumber = min(numbers);
+	const numberLength = String(biggestNumber).length;
+	return {numberLength, startNumber: smallestNumber};
+};

--- a/packages/renderer/src/min-max.ts
+++ b/packages/renderer/src/min-max.ts
@@ -1,0 +1,34 @@
+// Standard library Math.min and Math.max can throw
+// if array length is very long. Fixing this with own implementation
+
+export const min = (arr: number[]) => {
+	if (arr.length === 0) {
+		throw new Error('Array of 0 length');
+	}
+
+	let smallest = arr[0];
+	for (let i = 0; i < arr.length; i++) {
+		const elem = arr[i];
+		if (elem < smallest) {
+			smallest = elem;
+		}
+	}
+
+	return smallest;
+};
+
+export const max = (arr: number[]) => {
+	if (arr.length === 0) {
+		throw new Error('Array of 0 length');
+	}
+
+	let biggest = arr[0];
+	for (let i = 0; i < arr.length; i++) {
+		const elem = arr[i];
+		if (elem > biggest) {
+			biggest = elem;
+		}
+	}
+
+	return biggest;
+};

--- a/packages/renderer/src/stitcher.ts
+++ b/packages/renderer/src/stitcher.ts
@@ -14,6 +14,7 @@ import {getAssetAudioDetails} from './assets/get-asset-audio-details';
 import {calculateFfmpegFilters} from './calculate-ffmpeg-filters';
 import {createFfmpegComplexFilter} from './create-ffmpeg-complex-filter';
 import {DEFAULT_IMAGE_FORMAT} from './image-format';
+import {max, min} from './min-max';
 import {parseFfmpegProgress} from './parse-ffmpeg-progress';
 import {resolveAssetSrc} from './resolve-asset-src';
 import {validateFfmpeg} from './validate-ffmpeg';
@@ -90,8 +91,8 @@ export const stitchFramesToVideo = async (options: {
 			return f.match(/element-([0-9]+)/)?.[1] as string;
 		})
 		.map((f) => Number(f));
-	const biggestNumber = Math.max(...numbers);
-	const smallestNumber = Math.min(...numbers);
+	const biggestNumber = max(numbers);
+	const smallestNumber = min(numbers);
 	const numberLength = String(biggestNumber).length;
 
 	const encoderName = getCodecName(codec);

--- a/packages/renderer/src/test/min-max.test.ts
+++ b/packages/renderer/src/test/min-max.test.ts
@@ -1,0 +1,31 @@
+import {max, min} from '../min-max';
+import {expectToThrow} from './expect-to-throw';
+describe('min() and max()', () => {
+	test('Implemented min() functions correctly', () => {
+		expect(min([0, -30, 90, -120, 0])).toBe(-120);
+	});
+	test('Implemented max() functions correctly', () => {
+		expect(max([0, -30, 90, -120, 0])).toBe(90);
+	});
+
+	test('min() should throw on empty arr', () => {
+		expectToThrow(() => min([]), /Array of 0 length/);
+	});
+	test('max() should throw on empty arr', () => {
+		expectToThrow(() => min([]), /Array of 0 length/);
+	});
+
+	const bigArray = new Array(300000).fill(true).map((_, i) => {
+		return i;
+	});
+
+	test('Regular Math.max() should throw', () => {
+		expectToThrow(
+			() => Math.max(...bigArray),
+			/Maximum call stack size exceeded/
+		);
+	});
+	test('Custom max() should not throw', () => {
+		expect(max(bigArray)).toBe(299999);
+	});
+});


### PR DESCRIPTION
Rendering on very long videos (e.g. 8 hours) is broken because `Math.max(...new Array(300000).fill(1))` throws a `Maximum call stack exceeded` error. Fixing this by using our own `min()` and `max()` functions 🔥 

Fixes #395, should ping dLamSlo8#0898 on Discord to let them know it's fixed afterwards