### PR TITLE
fix next.js build

### DIFF
--- a/packages/core/src/RemotionRoot.tsx
+++ b/packages/core/src/RemotionRoot.tsx
@@ -43,6 +43,8 @@ export const RemotionRoot: React.FC = ({children}) => {
 				setFrame(f);
 				requestAnimationFrame(() => continueRender(id));
 			};
+
+			window.remotion_isPlayer = false;
 		}
 	}, []);
 

--- a/packages/core/src/audio/Audio.tsx
+++ b/packages/core/src/audio/Audio.tsx
@@ -1,4 +1,5 @@
 import React, {forwardRef, useCallback} from 'react';
+import {getRemotionEnvironment} from '../get-environment';
 import {Sequence} from '../sequencing';
 import {validateMediaProps} from '../validate-media-props';
 import {validateStartFromProps} from '../validate-start-from-props';
@@ -35,11 +36,11 @@ const AudioRefForwardingFunction: React.ForwardRefRenderFunction<
 
 	validateMediaProps(props, 'Audio');
 
-	if (process.env.NODE_ENV === 'development') {
-		return <AudioForDevelopment {...props} ref={ref} onError={onError} />;
+	if (getRemotionEnvironment() === 'rendering') {
+		return <AudioForRendering {...props} ref={ref} onError={onError} />;
 	}
 
-	return <AudioForRendering {...props} ref={ref} onError={onError} />;
+	return <AudioForDevelopment {...props} ref={ref} onError={onError} />;
 };
 
 export const Audio = forwardRef(AudioRefForwardingFunction);

--- a/packages/core/src/config/input-props.ts
+++ b/packages/core/src/config/input-props.ts
@@ -1,7 +1,9 @@
+import {getRemotionEnvironment} from '../get-environment';
+
 export const INPUT_PROPS_KEY = 'remotion.inputProps';
 
 export const getInputProps = () => {
-	if (process.env.NODE_ENV === 'production') {
+	if (getRemotionEnvironment() === 'rendering') {
 		const param = localStorage.getItem(INPUT_PROPS_KEY);
 		if (!param) {
 			return {};
@@ -11,5 +13,11 @@ export const getInputProps = () => {
 		return parsed;
 	}
 
-	return (process.env.INPUT_PROPS as unknown) as object | null;
+	if (getRemotionEnvironment() === 'preview') {
+		return (process.env.INPUT_PROPS as unknown) as object | null;
+	}
+
+	throw new Error(
+		'You cannot call `getInputProps()` from a <Player>. Instead, the props are available as React props from component that you passed as `component` prop.'
+	);
 };

--- a/packages/core/src/get-environment.ts
+++ b/packages/core/src/get-environment.ts
@@ -6,7 +6,7 @@ export type RemotionEnvironment =
 
 export const getRemotionEnvironment = (): RemotionEnvironment => {
 	if (process.env.NODE_ENV === 'production') {
-		if (window.remotion_isPlayer) {
+		if (typeof window !== 'undefined' && window.remotion_isPlayer) {
 			return 'player-production';
 		}
 
@@ -14,7 +14,7 @@ export const getRemotionEnvironment = (): RemotionEnvironment => {
 	}
 
 	if (process.env.NODE_ENV === 'development') {
-		if (window.remotion_isPlayer) {
+		if (typeof window !== 'undefined' && window.remotion_isPlayer) {
 			return 'player-development';
 		}
 

--- a/packages/core/src/get-environment.ts
+++ b/packages/core/src/get-environment.ts
@@ -1,0 +1,32 @@
+export type RemotionEnvironment =
+	| 'preview'
+	| 'rendering'
+	| 'player-development'
+	| 'player-production';
+
+export const getRemotionEnvironment = (): RemotionEnvironment => {
+	if (process.env.NODE_ENV === 'production') {
+		if (window.remotion_isPlayer) {
+			return 'player-production';
+		}
+
+		return 'rendering';
+	}
+
+	if (process.env.NODE_ENV === 'development') {
+		if (window.remotion_isPlayer) {
+			return 'player-development';
+		}
+
+		return 'preview';
+	}
+
+	// The Jest framework sets NODE_ENV as test.
+	// Right now we don't need to treat it in a special
+	// way which is good - defaulting to `rendering`.
+	if (process.env.NODE_ENV === 'test') {
+		return 'rendering';
+	}
+
+	throw new Error('Cannot determine Remotion environment');
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ declare global {
 		getStaticCompositions: () => TCompMetadata[];
 		remotion_setFrame: (frame: number) => void;
 		remotion_collectAssets: () => TAsset[];
+		remotion_isPlayer: boolean;
 	}
 }
 

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -1,3 +1,4 @@
+import {RemotionEnvironment} from '.';
 import {LooseAnyComponent} from './any-component';
 import {CompProps} from './Composition';
 import {
@@ -53,6 +54,7 @@ import {
 } from './config/webpack-caching';
 import * as CSSUtils from './default-css';
 import {FEATURE_FLAG_FIREFOX_SUPPORT} from './feature-flags';
+import {getRemotionEnvironment} from './get-environment';
 import {isAudioCodec} from './is-audio-codec';
 import * as perf from './perf';
 import {
@@ -152,6 +154,7 @@ export const Internals = {
 	validateDurationInFrames,
 	validateFps,
 	validateDimension,
+	getRemotionEnvironment,
 };
 
 export type {
@@ -169,4 +172,5 @@ export type {
 	MediaVolumeContextValue,
 	SetMediaVolumeContextValue,
 	LooseAnyComponent,
+	RemotionEnvironment,
 };

--- a/packages/core/src/internals.ts
+++ b/packages/core/src/internals.ts
@@ -1,4 +1,3 @@
-import {RemotionEnvironment} from '.';
 import {LooseAnyComponent} from './any-component';
 import {CompProps} from './Composition';
 import {
@@ -54,7 +53,7 @@ import {
 } from './config/webpack-caching';
 import * as CSSUtils from './default-css';
 import {FEATURE_FLAG_FIREFOX_SUPPORT} from './feature-flags';
-import {getRemotionEnvironment} from './get-environment';
+import {getRemotionEnvironment, RemotionEnvironment} from './get-environment';
 import {isAudioCodec} from './is-audio-codec';
 import * as perf from './perf';
 import {

--- a/packages/core/src/ready-manager.ts
+++ b/packages/core/src/ready-manager.ts
@@ -1,3 +1,5 @@
+import {getRemotionEnvironment} from './get-environment';
+
 if (typeof window !== 'undefined') {
 	window.ready = false;
 }
@@ -10,7 +12,7 @@ export const delayRender = (): number => {
 	handles.push(handle);
 	const called = Error().stack?.replace(/^Error/g, '') ?? '';
 
-	if (process.env.NODE_ENV === 'production') {
+	if (getRemotionEnvironment() === 'rendering') {
 		timeouts[handle] = setTimeout(() => {
 			throw new Error(
 				'A delayRender was called but not cleared after 25000ms. See https://remotion.dev/docs/timeout for help. The delayRender was called: ' +
@@ -29,7 +31,7 @@ export const delayRender = (): number => {
 export const continueRender = (handle: number): void => {
 	handles = handles.filter((h) => {
 		if (h === handle) {
-			if (process.env.NODE_ENV === 'production') {
+			if (getRemotionEnvironment() === 'rendering') {
 				clearTimeout(timeouts[handle] as number);
 			}
 

--- a/packages/core/src/setup-env-variables.ts
+++ b/packages/core/src/setup-env-variables.ts
@@ -1,22 +1,30 @@
+import {getRemotionEnvironment} from './get-environment';
+
 export const ENV_VARIABLES_LOCAL_STORAGE_KEY = 'remotion.envVariables';
 export const ENV_VARIABLES_ENV_NAME = 'ENV_VARIABLES' as const;
 
 const getEnvVariables = (): Record<string, string> => {
-	if (process.env.NODE_ENV === 'production') {
+	if (getRemotionEnvironment() === 'rendering') {
 		const param = localStorage.getItem(ENV_VARIABLES_LOCAL_STORAGE_KEY);
 		if (!param) {
 			return {};
 		}
 
-		return {...JSON.parse(param), NODE_ENV: 'production'};
+		return {...JSON.parse(param), NODE_ENV: process.env.NODE_ENV};
 	}
 
-	// Webpack will convert this to an object at compile time.
-	// Don't convert this syntax to a computed property.
-	return {
-		...((process.env.ENV_VARIABLES as unknown) as Record<string, string>),
-		NODE_ENV: 'development',
-	};
+	if (getRemotionEnvironment() === 'preview') {
+		// Webpack will convert this to an object at compile time.
+		// Don't convert this syntax to a computed property.
+		return {
+			...((process.env.ENV_VARIABLES as unknown) as Record<string, string>),
+			NODE_ENV: process.env.NODE_ENV as string,
+		};
+	}
+
+	throw new Error(
+		'Can only call getEnvVariables() if environment is `rendering` or `preview`'
+	);
 };
 
 export const setupEnvVariables = () => {

--- a/packages/core/src/test/input-props.test.ts
+++ b/packages/core/src/test/input-props.test.ts
@@ -13,7 +13,7 @@ describe('input props', () => {
 	});
 
 	test('input props in non production env', () => {
-		process.env.NODE_ENV = 'dev';
+		process.env.NODE_ENV = 'development';
 		const inputProps = {
 			firstProperty: 'firstProperty',
 			secondProperty: 'secondProperty',

--- a/packages/core/src/video/Video.tsx
+++ b/packages/core/src/video/Video.tsx
@@ -1,4 +1,5 @@
 import React, {forwardRef} from 'react';
+import {getRemotionEnvironment} from '../get-environment';
 import {Sequence} from '../sequencing';
 import {validateMediaProps} from '../validate-media-props';
 import {validateStartFromProps} from '../validate-start-from-props';
@@ -35,11 +36,11 @@ const VideoForwardingFunction: React.ForwardRefRenderFunction<
 
 	validateMediaProps(props, 'Video');
 
-	if (process.env.NODE_ENV === 'development') {
-		return <VideoForDevelopment {...otherProps} ref={ref} />;
+	if (getRemotionEnvironment() === 'rendering') {
+		return <VideoForRendering {...otherProps} ref={ref} />;
 	}
 
-	return <VideoForRendering {...otherProps} ref={ref} />;
+	return <VideoForDevelopment {...otherProps} ref={ref} />;
 };
 
 export const Video = forwardRef(VideoForwardingFunction);

--- a/packages/docs/docs/get-input-props.md
+++ b/packages/docs/docs/get-input-props.md
@@ -9,6 +9,10 @@ Using this method, you can retrieve inputs that you pass in from the command lin
 
 You should whenever possible prefer to retrieve props directly in your composition, like you would read props from a component if you were to code a React application, but this method is useful if you want to retrieve the input props outside of a composition.
 
+:::info
+This method is not available when inside a Remotion Player. Instead, get the props as React props from the component you passed as the `component` prop to the player.
+:::
+
 ## API
 
 Pass in a [parseable](/docs/cli) JSON representation using the `--props` flag to either `remotion preview` or `remotion render`:

--- a/packages/gif/src/Gif.tsx
+++ b/packages/gif/src/Gif.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
+import {Internals} from 'remotion';
 import {GifForDevelopment} from './GifForDevelopment';
 import {GifForRendering} from './GifForRendering';
 import {RemotionGifProps} from './props';
 
 export const Gif = (props: RemotionGifProps) => {
-	if (process.env.NODE_ENV === 'development') {
-		return <GifForDevelopment {...props} />;
+	if (Internals.getRemotionEnvironment() === 'rendering') {
+		return <GifForRendering {...props} />;
 	}
 
-	return <GifForRendering {...props} />;
+	return <GifForDevelopment {...props} />;
 };

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -3,6 +3,7 @@ import React, {
 	MutableRefObject,
 	useCallback,
 	useImperativeHandle,
+	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
@@ -52,10 +53,6 @@ Internals.CSSUtils.injectCSS(
 	Internals.CSSUtils.makeDefaultCSS(`.${PLAYER_CSS_CLASSNAME}`)
 );
 
-if (typeof window !== 'undefined') {
-	window.remotion_isPlayer = true;
-}
-
 export const PlayerFn = <T,>(
 	{
 		durationInFrames,
@@ -74,6 +71,11 @@ export const PlayerFn = <T,>(
 	}: PlayerProps<T>,
 	ref: MutableRefObject<PlayerRef>
 ) => {
+	useLayoutEffect(() => {
+		if (typeof window !== 'undefined') {
+			window.remotion_isPlayer = true;
+		}
+	}, []);
 	const component = Internals.useLazyComponent(componentProps);
 	const [frame, setFrame] = useState(0);
 	const [playing, setPlaying] = useState<boolean>(false);

--- a/packages/player/src/Player.tsx
+++ b/packages/player/src/Player.tsx
@@ -52,6 +52,10 @@ Internals.CSSUtils.injectCSS(
 	Internals.CSSUtils.makeDefaultCSS(`.${PLAYER_CSS_CLASSNAME}`)
 );
 
+if (typeof window !== 'undefined') {
+	window.remotion_isPlayer = true;
+}
+
 export const PlayerFn = <T,>(
 	{
 		durationInFrames,


### PR DESCRIPTION
Fixes #352 

Next.JS build sets process.env.NODE_ENV === 'production', making remotion think that it is in a render stage.
Fixing it by distinguishing the cases.