### PR TITLE
pass inputProps to component in preview

### DIFF
--- a/packages/cli/src/editor/components/Preview.tsx
+++ b/packages/cli/src/editor/components/Preview.tsx
@@ -1,6 +1,6 @@
 import {PlayerInternals, Size} from '@remotion/player';
 import React, {Suspense, useContext, useMemo} from 'react';
-import {Internals, useVideoConfig} from 'remotion';
+import {getInputProps, Internals, useVideoConfig} from 'remotion';
 import styled from 'styled-components';
 import {
 	checkerboardBackgroundColor,
@@ -76,6 +76,7 @@ const Inner: React.FC<{
 	}, [centerX, centerY, config.height, config.width, scale]);
 
 	const Component = video ? video.component : null;
+	const inputProps = getInputProps();
 
 	return (
 		<Suspense fallback={<div>loading...</div>}>
@@ -91,7 +92,10 @@ const Inner: React.FC<{
 					}}
 				>
 					{Component ? (
-						<Component {...(((video?.props as unknown) as {}) ?? {})} />
+						<Component
+							{...(((video?.props as unknown) as {}) ?? {})}
+							{...inputProps}
+						/>
 					) : null}
 				</Container>
 			</div>


### PR DESCRIPTION
Previously you could only get it using `getInputProps` but that is not consistent with how it works during rendering. Fixes #428 