### PR TITLE
disable @typescript-eslint/explicit-module-boundary-types rule by default

### DIFF
--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -43,6 +43,7 @@ const getRules = (typescript: boolean) => {
     "@remotion/warn-native-media-tag": "warn",
     "@remotion/deterministic-randomness": "warn",
     "@remotion/no-string-assets": "warn",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
   };
 };
 


### PR DESCRIPTION
Many people use `function MyComp()` to define their components, maybe overkill to give them a warning.

Fixes #418 