### PR TITLE
set environment variables earlier

### DIFF
--- a/packages/bundler/src/renderEntry.tsx
+++ b/packages/bundler/src/renderEntry.tsx
@@ -16,7 +16,6 @@ import {
 import {LooseAnyComponent} from 'remotion/src/any-component';
 
 Internals.CSSUtils.injectCSS(Internals.CSSUtils.makeDefaultCSS(null));
-Internals.setupEnvVariables();
 
 const Root = Internals.getRoot();
 

--- a/packages/bundler/src/setup-env-variables.ts
+++ b/packages/bundler/src/setup-env-variables.ts
@@ -1,0 +1,3 @@
+import {Internals} from 'remotion';
+
+Internals.setupEnvVariables();

--- a/packages/bundler/src/webpack-config.ts
+++ b/packages/bundler/src/webpack-config.ts
@@ -52,6 +52,7 @@ export const webpackConfig = ({
 			: false,
 		devtool: 'cheap-module-source-map',
 		entry: [
+			require.resolve('./setup-env-variables'),
 			environment === 'development'
 				? require.resolve('webpack-hot-middleware/client') + '?overlay=true'
 				: null,

--- a/packages/cli/src/previewEntry.tsx
+++ b/packages/cli/src/previewEntry.tsx
@@ -4,7 +4,6 @@ import '../styles/styles.css';
 import {Editor} from './editor/components/Editor';
 
 Internals.CSSUtils.injectCSS(Internals.CSSUtils.makeDefaultCSS(null));
-Internals.setupEnvVariables();
 
 render(
 	<Internals.RemotionRoot>


### PR DESCRIPTION
Fixes #422 

At first I thought that this technique would not work if you cached the webpack bundle, but I verified that it works even with cache enabled
